### PR TITLE
refactor: rename to the CONTEXT.md vocabulary

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -25,8 +25,8 @@ var priceTable = map[string]float64{
 	"14x28x12": 13189, "16x36x12": 14789,
 }
 
-// addOnPrices maps add-on keys to dollar amounts.
-var addOnPrices = map[string]float64{
+// optionPrices maps add-on keys to dollar amounts.
+var optionPrices = map[string]float64{
 	"garage_door_6x7":        450,
 	"garage_door_8x7":        500,
 	"garage_door_additional": 600,
@@ -64,9 +64,9 @@ type Placement struct {
 	RotationZ   float64 `json:"rotationZ,omitempty"`
 }
 
-// AddOnConfig holds the client-supplied add-on state.
+// OptionConfig holds the client-supplied add-on state.
 // We re-derive price server-side for security; we just store the state.
-type AddOnConfig struct {
+type OptionConfig struct {
 	Enabled   bool    `json:"enabled"`
 	Size      string  `json:"size,omitempty"`
 	Count     int     `json:"count,omitempty"`
@@ -77,41 +77,41 @@ type AddOnConfig struct {
 	Sqft      float64 `json:"sqft,omitempty"`
 }
 
-// AddOns holds all add-on states.
-type AddOns struct {
-	GarageDoor     AddOnConfig `json:"garageDoor"`
-	AdditionalDoor AddOnConfig `json:"additionalDoor"`
-	EntryDoor      AddOnConfig `json:"entryDoor"`
-	VinylWindows   AddOnConfig `json:"vinylWindows"`
-	OctagonWindow  AddOnConfig `json:"octagonWindow"`
-	Skylight       AddOnConfig `json:"skylight"`
-	Shutters       AddOnConfig `json:"shutters"`
-	Ramp           AddOnConfig `json:"ramp"`
-	OctagonVent    AddOnConfig `json:"octagonVent"`
-	Workbench      AddOnConfig `json:"workbench"`
-	Pegboard       AddOnConfig `json:"pegboard"`
-	Loft           AddOnConfig `json:"loft"`
+// Options holds all add-on states.
+type Options struct {
+	GarageDoor     OptionConfig `json:"garageDoor"`
+	AdditionalDoor OptionConfig `json:"additionalDoor"`
+	EntryDoor      OptionConfig `json:"entryDoor"`
+	VinylWindows   OptionConfig `json:"vinylWindows"`
+	OctagonWindow  OptionConfig `json:"octagonWindow"`
+	Skylight       OptionConfig `json:"skylight"`
+	Shutters       OptionConfig `json:"shutters"`
+	Ramp           OptionConfig `json:"ramp"`
+	OctagonVent    OptionConfig `json:"octagonVent"`
+	Workbench      OptionConfig `json:"workbench"`
+	Pegboard       OptionConfig `json:"pegboard"`
+	Loft           OptionConfig `json:"loft"`
 }
 
-// calculateAddOnTotal derives total add-on price from the AddOns state.
-func calculateAddOnTotal(ao AddOns) float64 {
+// calculateOptionTotal derives total add-on price from the Options state.
+func calculateOptionTotal(ao Options) float64 {
 	total := 0.0
 
 	if ao.GarageDoor.Enabled {
 		if ao.GarageDoor.Size == "8x7" {
-			total += addOnPrices["garage_door_8x7"]
+			total += optionPrices["garage_door_8x7"]
 		} else {
-			total += addOnPrices["garage_door_6x7"]
+			total += optionPrices["garage_door_6x7"]
 		}
 	}
 	if ao.AdditionalDoor.Enabled {
-		total += addOnPrices["garage_door_additional"]
+		total += optionPrices["garage_door_additional"]
 	}
 	if ao.EntryDoor.Enabled {
 		if ao.EntryDoor.Type == "nine_light" {
-			total += addOnPrices["entry_door_nine_light"]
+			total += optionPrices["entry_door_nine_light"]
 		} else {
-			total += addOnPrices["entry_door_steel"]
+			total += optionPrices["entry_door_steel"]
 		}
 	}
 	if ao.VinylWindows.Enabled {
@@ -119,43 +119,43 @@ func calculateAddOnTotal(ao AddOns) float64 {
 		if count < 1 {
 			count = 1
 		}
-		total += addOnPrices["window_vinyl_slide"] * float64(count)
+		total += optionPrices["window_vinyl_slide"] * float64(count)
 	}
 	if ao.OctagonWindow.Enabled {
-		total += addOnPrices["window_octagon"]
+		total += optionPrices["window_octagon"]
 	}
 	if ao.Skylight.Enabled {
 		ft := ao.Skylight.RunningFt
 		if ft <= 0 {
 			ft = 8
 		}
-		total += addOnPrices["skylight_per_ft"] * ft
+		total += optionPrices["skylight_per_ft"] * ft
 	}
 	if ao.Shutters.Enabled {
 		pairs := ao.Shutters.Pairs
 		if pairs < 1 {
 			pairs = 1
 		}
-		total += addOnPrices["shutters_per_pair"] * float64(pairs)
+		total += optionPrices["shutters_per_pair"] * float64(pairs)
 	}
 	if ao.Ramp.Enabled {
 		if ao.Ramp.Size == "large" {
-			total += addOnPrices["ramp_large"]
+			total += optionPrices["ramp_large"]
 		} else {
-			total += addOnPrices["ramp_small"]
+			total += optionPrices["ramp_small"]
 		}
 	}
 	if ao.OctagonVent.Enabled {
-		total += addOnPrices["vent_octagon"]
+		total += optionPrices["vent_octagon"]
 	}
 	if ao.Workbench.Enabled {
-		total += addOnPrices["workbench_per_ft"] * ao.Workbench.RunningFt
+		total += optionPrices["workbench_per_ft"] * ao.Workbench.RunningFt
 	}
 	if ao.Pegboard.Enabled {
-		total += addOnPrices["pegboard_per_sheet"] * float64(ao.Pegboard.Sheets)
+		total += optionPrices["pegboard_per_sheet"] * float64(ao.Pegboard.Sheets)
 	}
 	if ao.Loft.Enabled {
-		total += addOnPrices["loft_per_sqft"] * ao.Loft.Sqft
+		total += optionPrices["loft_per_sqft"] * ao.Loft.Sqft
 	}
 
 	return total
@@ -167,12 +167,12 @@ type Design struct {
 	Width      int          `json:"width"`
 	Length     int          `json:"length"`
 	WallHeight int          `json:"wallHeight"`
-	Style      string       `json:"style"`
+	Model      string       `json:"model"`
 	Color      string       `json:"color"`
 	RoofColor  string       `json:"roofColor"`
 	TrimColor  string       `json:"trimColor"`
 	Placements []*Placement `json:"placements"`
-	AddOns     AddOns       `json:"addOns"`
+	Options    Options      `json:"options"`
 	Price      float64      `json:"price"`
 	CreatedAt  string       `json:"createdAt"`
 }
@@ -208,25 +208,25 @@ func saveDesign(c *gin.Context) {
 		return
 	}
 
-	if input.Style != "Gable" && input.Style != "Barn" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Style must be 'Gable' or 'Barn'"})
+	if input.Model != "Gable" && input.Model != "Barn" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Model must be 'Gable' or 'Barn'"})
 		return
 	}
 
 	// Server-side price calculation (ignore client price for base)
-	serverPrice := basePrice + calculateAddOnTotal(input.AddOns)
+	serverPrice := basePrice + calculateOptionTotal(input.Options)
 
 	design := &Design{
 		ID:         uuid.New().String(),
 		Width:      input.Width,
 		Length:     input.Length,
 		WallHeight: input.WallHeight,
-		Style:      input.Style,
+		Model:      input.Model,
 		Color:      input.Color,
 		RoofColor:  input.RoofColor,
 		TrimColor:  input.TrimColor,
 		Placements: input.Placements,
-		AddOns:     input.AddOns,
+		Options:    input.Options,
 		Price:      serverPrice,
 		CreatedAt:  time.Now().Format(time.RFC3339),
 	}

--- a/backend/main_test.go
+++ b/backend/main_test.go
@@ -28,7 +28,7 @@ func post(t *testing.T, body string) (*httptest.ResponseRecorder, Design) {
 // The Quote is the server's number, not the client's. Expected prices come
 // from shed-options.md.
 func TestQuoteIgnoresClientSuppliedPrice(t *testing.T) {
-	rec, design := post(t, `{"width":12,"length":16,"wallHeight":10,"style":"Gable","price":1}`)
+	rec, design := post(t, `{"width":12,"length":16,"wallHeight":10,"model":"Gable","price":1}`)
 
 	if rec.Code != http.StatusCreated {
 		t.Fatalf("want 201, got %d: %s", rec.Code, rec.Body.String())
@@ -39,7 +39,7 @@ func TestQuoteIgnoresClientSuppliedPrice(t *testing.T) {
 }
 
 func TestRejectsCombinationNotInCatalog(t *testing.T) {
-	rec, _ := post(t, `{"width":13,"length":17,"wallHeight":10,"style":"Gable"}`)
+	rec, _ := post(t, `{"width":13,"length":17,"wallHeight":10,"model":"Gable"}`)
 
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("want 400 for a combination we do not sell, got %d", rec.Code)
@@ -47,7 +47,7 @@ func TestRejectsCombinationNotInCatalog(t *testing.T) {
 }
 
 func TestRejectsUnknownModel(t *testing.T) {
-	rec, _ := post(t, `{"width":12,"length":16,"wallHeight":10,"style":"Tudor"}`)
+	rec, _ := post(t, `{"width":12,"length":16,"wallHeight":10,"model":"Tudor"}`)
 
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("want 400 for an unknown Model, got %d", rec.Code)
@@ -55,7 +55,7 @@ func TestRejectsUnknownModel(t *testing.T) {
 }
 
 func TestSavedDesignCanBeFetchedByID(t *testing.T) {
-	_, saved := post(t, `{"width":12,"length":16,"wallHeight":10,"style":"Gable"}`)
+	_, saved := post(t, `{"width":12,"length":16,"wallHeight":10,"model":"Gable"}`)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/design/"+saved.ID, nil)
 	rec := httptest.NewRecorder()
@@ -75,7 +75,7 @@ func TestSavedDesignCanBeFetchedByID(t *testing.T) {
 
 // Interior Options: workbench $35/running ft, pegboard $70/sheet, loft $4/sqft.
 func TestQuotePricesInteriorOptions(t *testing.T) {
-	_, design := post(t, `{"width":12,"length":16,"wallHeight":10,"style":"Gable","addOns":{
+	_, design := post(t, `{"width":12,"length":16,"wallHeight":10,"model":"Gable","options":{
 		"workbench":{"enabled":true,"runningFt":8},
 		"pegboard":{"enabled":true,"sheets":3},
 		"loft":{"enabled":true,"sqft":96}}}`)

--- a/frontend/src/ARCHITECTURE.md
+++ b/frontend/src/ARCHITECTURE.md
@@ -102,7 +102,7 @@ File: `src/store/shedStore.js`
 | `porch.enabled` | `boolean` | `false` | |
 | `porch.wall` | `string` | `'front'` | `'front'` \| `'back'` \| `'left'` \| `'right'` |
 | `porch.depth` | `number` | `6` | feet |
-| `addOns.garageDoor.style` | `string` | `'sectional'` | `'sectional'` \| `'rollup'`; auto-set by `setStyle` (Barn → `'rollup'`, Gable → `'sectional'`) |
+| `options.garageDoor.style` | `string` | `'sectional'` | `'sectional'` \| `'rollup'`; auto-set by `setStyle` (Barn → `'rollup'`, Gable → `'sectional'`) |
 | `price` | `number` | `0` | calculated, not set manually |
 | `placements` | `Placement[]` | `[]` | see Placement shape below |
 
@@ -127,7 +127,7 @@ File: `src/store/shedStore.js`
 |---|---|---|
 | `setWidth` | `(number) => void` | Updates width |
 | `setLength` | `(number) => void` | Updates length |
-| `setStyle` | `(string) => void` | Switches Gable/Barn; auto-sets `addOns.garageDoor.style` (`'rollup'` for Barn, `'sectional'` for Gable) |
+| `setStyle` | `(string) => void` | Switches Gable/Barn; auto-sets `options.garageDoor.style` (`'rollup'` for Barn, `'sectional'` for Gable) |
 | `setColor` | `(string) => void` | Siding hex color |
 | `setRoofColor` | `(string) => void` | Roof hex color |
 | `setTrimColor` | `(string) => void` | Trim hex color |

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,7 +7,7 @@ import { ControlPanel } from './components/ControlPanel';
 import { ComponentPreview } from './pages/ComponentPreview';
 import { ReferenceMatch } from './pages/ReferenceMatch';
 import { useShedStore } from './store/shedStore';
-import { lookupBasePrice, getAddOnLineItems, getShedTier } from './utils/pricingUtils';
+import { lookupBasePrice, getOptionLineItems, getShedTier } from './utils/pricingUtils';
 import './App.css';
 
 const NAV_H  = 48;
@@ -28,12 +28,12 @@ export default function App() {
   const [page, setPage]           = useState('configurator');
   const [drawerOpen, setDrawerOpen] = useState(true);
 
-  const { width, length, wallHeight, style, color, roofColor, addOns } = useShedStore();
+  const { width, length, wallHeight, model, color, roofColor, options } = useShedStore();
 
   // Price for canvas overlay
   const base      = lookupBasePrice(width, length, wallHeight) ?? 0;
-  const addOnTotal = getAddOnLineItems(addOns).reduce((s, i) => s + i.amount, 0);
-  const total     = base + addOnTotal;
+  const optionTotal = getOptionLineItems(options).reduce((s, i) => s + i.amount, 0);
+  const total     = base + optionTotal;
   const tier      = getShedTier(wallHeight);
 
   return (
@@ -117,7 +117,7 @@ export default function App() {
               <pointLight position={[15, 20, 10]} intensity={1} />
               <pointLight position={[-15, 20, -10]} intensity={0.5} />
               <Suspense fallback={null}>
-                {style === 'Barn' ? (
+                {model === 'Barn' ? (
                   <BarnShed width={width} length={length} wallHeight={wallHeight} color={color} roofColor={roofColor} />
                 ) : (
                   <GableShed width={width} length={length} wallHeight={wallHeight} color={color} roofColor={roofColor} />

--- a/frontend/src/components/BarnShed/BarnShed.jsx
+++ b/frontend/src/components/BarnShed/BarnShed.jsx
@@ -4,7 +4,7 @@ import { ShedWall } from '../shed/walls/ShedWall';
 import { GambrelRoof } from '../shed/roofs/GambrelRoof';
 import { Porch } from '../shed/extras/Porch';
 import { Ramp } from '../shed/extras/Ramp';
-import { Skids } from '../common/Skids';
+import { Runners } from '../common/Runners';
 import { BarnTrim } from '../shed/trim/BarnTrim';
 
 // Front/back faces are provided by GambrelRoof's ExtrudeGeometry end-caps (siding material).
@@ -13,7 +13,7 @@ const WALL_SIDES = ['left', 'right'];
 
 /**
  * BarnShed — composition wrapper.
- * Assembles: 2× ShedWall (left/right) + GambrelRoof + Skids + optional Porch.
+ * Assembles: 2× ShedWall (left/right) + GambrelRoof + Runners + optional Porch.
  * Front/back barn faces come from GambrelRoof end-caps (siding shader, groups 0 & 1).
  */
 export const BarnShed = ({
@@ -31,8 +31,8 @@ export const BarnShed = ({
 	const roofLowerPitch = useShedStore((s) => s.roofLowerPitch);
 	const roofUpperPitch = useShedStore((s) => s.roofUpperPitch);
 	const porch = useShedStore((s) => s.porch);
-	const addOns = useShedStore((s) => s.addOns);
-	const garageDoorStyle = useShedStore((s) => s.addOns.garageDoor.style ?? 'sectional');
+	const options = useShedStore((s) => s.options);
+	const garageDoorStyle = useShedStore((s) => s.options.garageDoor.style ?? 'sectional');
 	useEffect(() => {
 		// Barn has no discrete front wall mesh — placement raycasting not yet wired
 		if (onShedMeshReady) onShedMeshReady(null, { width, length, wallHeight });
@@ -57,13 +57,13 @@ export const BarnShed = ({
 			))}
 
 			{/* Optional ramp */}
-			{addOns.ramp.enabled && (
+			{options.ramp.enabled && (
 				<Ramp
 					shedWidth={width}
 					shedLength={length}
 					wallHeight={wallHeight}
 					wall="front"
-					size={addOns.ramp.size}
+					size={options.ramp.size}
 				/>
 			)}
 
@@ -78,7 +78,7 @@ export const BarnShed = ({
 				roofMaterial={roofMaterial}
 				color={color}
 				sidingTexture={sidingTexture}
-				skylight={addOns.skylight}
+				skylight={options.skylight}
 				overhangEave={0.5}
 			/>
 
@@ -91,8 +91,8 @@ export const BarnShed = ({
 				overhangEave={0.5}
 			/>
 
-			{/* Foundation: floor deck + 5 longitudinal skid beams */}
-			<Skids
+			{/* Foundation: floor deck + 5 longitudinal runners */}
+			<Runners
 				width={width}
 				length={length}
 			/>

--- a/frontend/src/components/Canvas3D.jsx
+++ b/frontend/src/components/Canvas3D.jsx
@@ -74,7 +74,7 @@ function RaycastingInteraction({ shedMesh, shedDimensions, onWallClick }) {
 }
 
 export const Canvas3D = ({ onPlacementInteraction = null }) => {
-	const { width, length, style, color, roofColor } = useShedStore();
+	const { width, length, model, color, roofColor } = useShedStore();
 	const [shedMesh, setShedMesh] = useState(null);
 	const [shedDimensions, setShedDimensions] = useState(null);
 
@@ -103,7 +103,7 @@ export const Canvas3D = ({ onPlacementInteraction = null }) => {
 			<Shed
 				width={width}
 				length={length}
-				style={style}
+				model={model}
 				color={color}
 				roofColor={roofColor}
 				onShedMeshReady={handleShedMeshReady}

--- a/frontend/src/components/ControlPanel.jsx
+++ b/frontend/src/components/ControlPanel.jsx
@@ -2,30 +2,30 @@ import { useState } from 'react';
 import { useShedStore } from '../store/shedStore';
 import { useDesignPersistence } from '../hooks/useDesignPersistence';
 import { DimensionsSection }     from './controls/DimensionsSection';
-import { StyleSection }          from './controls/StyleSection';
+import { ModelSection }          from './controls/ModelSection';
 import { TrimAndDetailsSection } from './controls/TrimAndDetailsSection';
 import { ColorSection }          from './controls/ColorSection';
-import { AddOnsSection }         from './controls/AddOnsSection';
+import { OptionsSection }         from './controls/OptionsSection';
 import { ActionButtons }         from './controls/ActionButtons';
-import { lookupBasePrice, getAddOnLineItems } from '../utils/pricingUtils';
+import { lookupBasePrice, getOptionLineItems } from '../utils/pricingUtils';
 
 const TABS = [
   { id: 'dimensions', label: 'Size' },
-  { id: 'style',      label: 'Style' },
+  { id: 'model',      label: 'Model' },
   { id: 'colors',     label: 'Colors' },
-  { id: 'addons',     label: 'Add-Ons' },
+  { id: 'options',    label: 'Options' },
 ];
 
 export const ControlPanel = ({ onClose }) => {
   const [activeTab, setActiveTab] = useState('dimensions');
 
-  const { style, color, roofColor, setStyle, setColor, setRoofColor,
-          width, length, wallHeight, addOns, reset } = useShedStore();
+  const { model, color, roofColor, setModel, setColor, setRoofColor,
+          width, length, wallHeight, options, reset } = useShedStore();
   const { save, load, isLoading } = useDesignPersistence();
 
   const base     = lookupBasePrice(width, length, wallHeight) ?? 0;
-  const addOnAmt = getAddOnLineItems(addOns).reduce((s, i) => s + i.amount, 0);
-  const total    = base + addOnAmt;
+  const optionAmt = getOptionLineItems(options).reduce((s, i) => s + i.amount, 0);
+  const total    = base + optionAmt;
 
   const handleSave = async () => {
     try {
@@ -115,9 +115,9 @@ export const ControlPanel = ({ onClose }) => {
             <DimensionsSection />
           )}
 
-          {activeTab === 'style' && (
+          {activeTab === 'model' && (
             <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
-              <StyleSection style={style} onStyleChange={setStyle} />
+              <ModelSection model={model} onModelChange={setModel} />
               <TrimAndDetailsSection />
             </div>
           )}
@@ -129,8 +129,8 @@ export const ControlPanel = ({ onClose }) => {
             </div>
           )}
 
-          {activeTab === 'addons' && (
-            <AddOnsSection />
+          {activeTab === 'options' && (
+            <OptionsSection />
           )}
         </div>
       </div>

--- a/frontend/src/components/GableShed/GableShed.jsx
+++ b/frontend/src/components/GableShed/GableShed.jsx
@@ -5,7 +5,7 @@ import { GableRoof } from '../shed/roofs/GableRoof';
 import { GableEnd } from '../shed/roofs/GableEnd';
 import { Porch } from '../shed/extras/Porch';
 import { Ramp } from '../shed/extras/Ramp';
-import { Skids } from '../common/Skids';
+import { Runners } from '../common/Runners';
 import { GableTrim } from '../shed/trim/GableTrim';
 
 const WALL_SIDES = ['front', 'back', 'left', 'right'];
@@ -13,7 +13,7 @@ const ROOF_HEIGHT = 4; // ft above wall top
 
 /**
  * GableShed — composition wrapper.
- * Assembles: 4× ShedWall + 2× GableEnd + GableRoof + Skids + optional Porch.
+ * Assembles: 4× ShedWall + 2× GableEnd + GableRoof + Runners + optional Porch.
  * All geometry and shader logic lives in the individual components.
  */
 export const GableShed = ({
@@ -30,8 +30,8 @@ export const GableShed = ({
 	const sidingTexture = useShedStore((s) => s.sidingTexture);
 	const roofMaterial = useShedStore((s) => s.roofMaterial);
 	const porch = useShedStore((s) => s.porch);
-	const addOns = useShedStore((s) => s.addOns);
-	const garageDoorStyle = useShedStore((s) => s.addOns.garageDoor.style ?? 'sectional');
+	const options = useShedStore((s) => s.options);
+	const garageDoorStyle = useShedStore((s) => s.options.garageDoor.style ?? 'sectional');
 
 	// Expose front-wall mesh for raycasting / placement interaction
 	useEffect(() => {
@@ -68,7 +68,7 @@ export const GableShed = ({
 				roofHeight={ROOF_HEIGHT}
 				color={color}
 				sidingTexture={sidingTexture}
-				showOctagonWindow={addOns.octagonWindow.enabled}
+				showOctagonWindow={options.octagonWindow.enabled}
 				trimColor={trimColor}
 			/>
 			<GableEnd
@@ -79,7 +79,7 @@ export const GableShed = ({
 				roofHeight={ROOF_HEIGHT}
 				color={color}
 				sidingTexture={sidingTexture}
-				showOctagonWindow={addOns.octagonWindow.enabled}
+				showOctagonWindow={options.octagonWindow.enabled}
 				trimColor={trimColor}
 			/>
 
@@ -100,24 +100,24 @@ export const GableShed = ({
 				roofHeight={ROOF_HEIGHT}
 				roofColor={roofColor}
 				roofMaterial={roofMaterial}
-				skylight={addOns.skylight}
+				skylight={options.skylight}
 				overhangEave={0.5}
 			/>
 
-			{/* Foundation: floor deck + 5 longitudinal skid beams */}
-			<Skids
+			{/* Foundation: floor deck + 5 longitudinal runners */}
+			<Runners
 				width={width}
 				length={length}
 			/>
 
 			{/* Optional ramp */}
-			{addOns.ramp.enabled && (
+			{options.ramp.enabled && (
 				<Ramp
 					shedWidth={width}
 					shedLength={length}
 					wallHeight={wallHeight}
 					wall="front"
-					size={addOns.ramp.size}
+					size={options.ramp.size}
 				/>
 			)}
 

--- a/frontend/src/components/ShedConfigurator.jsx
+++ b/frontend/src/components/ShedConfigurator.jsx
@@ -14,13 +14,13 @@ export const ShedConfigurator = ({
 	width = 10,
 	length = 12,
 	wallHeight = 8,
-	style = 'Gable',
+	model = 'Gable',
 	color = '#8B4513',
 	roofColor = '#2F4F4F',
 	onShedMeshReady = null,
 }) => {
 	// Route to appropriate style-specific component
-	if (style === 'Barn') {
+	if (model === 'Barn') {
 		return (
 			<BarnShed
 				width={width}

--- a/frontend/src/components/common/Runners.jsx
+++ b/frontend/src/components/common/Runners.jsx
@@ -1,30 +1,30 @@
 import * as THREE from 'three';
 
 // 4×4 nominal lumber: 3.5" actual = ~0.292 ft, rounded to 0.333 for visual clarity
-const SKID_SIZE = 0.333;
+const RUNNER_SIZE = 0.333;
 // Nominal floor deck thickness (~1.5" T&G planks)
 const FLOOR_THICKNESS = 0.125;
 const NUM_SKIDS = 5;
 
 /**
- * Skids + Floor Foundation Component
+ * Runners + Floor Foundation Component
  *
- * Renders 5 longitudinal 4×4 pressure-treated skid beams running the full shed
+ * Renders 5 longitudinal 4×4 pressure-treated runners running the full shed
  * length, evenly spaced across the width, topped with a floor deck panel.
  *
  * Coordinate convention (matches ShedWall):
  *   Y = 0  — shed floor / top of deck / bottom of walls
- *   Y < 0  — below floor (skids, ground)
+ *   Y < 0  — below floor (runners, ground)
  */
-export const Skids = ({
+export const Runners = ({
 	width,
 	length,
 	foundationColor = '#6B4C2A', // pressure-treated wood tone
 }) => {
 	// Floor deck: thin panel sitting just below Y=0 so its top face is flush with wall bottoms
 	const floorY = -FLOOR_THICKNESS / 2;
-	// Skids run under the floor; their tops touch the floor bottom
-	const skidY = -FLOOR_THICKNESS - SKID_SIZE / 2;
+	// Runners run under the floor; their tops touch the floor bottom
+	const runnerY = -FLOOR_THICKNESS - RUNNER_SIZE / 2;
 	// 5 beams evenly spread across the full shed width
 	const xPositions = Array.from({ length: NUM_SKIDS }, (_, i) =>
 		-width / 2 + i * (width / (NUM_SKIDS - 1))
@@ -44,15 +44,15 @@ export const Skids = ({
 				/>
 			</mesh>
 
-			{/* 5 longitudinal 4×4 skid beams */}
+			{/* 5 longitudinal 4×4 runners */}
 			{xPositions.map((x, i) => (
 				<mesh
 					key={i}
-					position={[x, skidY, 0]}
+					position={[x, runnerY, 0]}
 					castShadow
 					receiveShadow
 				>
-					<boxGeometry args={[SKID_SIZE, SKID_SIZE, length]} />
+					<boxGeometry args={[RUNNER_SIZE, RUNNER_SIZE, length]} />
 					<meshStandardMaterial
 						color={foundationColor}
 						roughness={0.8}

--- a/frontend/src/components/controls/ModelSection.jsx
+++ b/frontend/src/components/controls/ModelSection.jsx
@@ -26,23 +26,23 @@ const BarnSVG = () => (
   </svg>
 );
 
-const STYLES = [
+const MODELS = [
   { value: 'Gable', label: 'Gable',        desc: 'Classic peaked roof',  Icon: GableSVG },
   { value: 'Barn',  label: 'Barn (Gambrel)', desc: 'Double-slope barn roof', Icon: BarnSVG  },
 ];
 
-export const StyleSection = ({ style, onStyleChange }) => (
+export const ModelSection = ({ model, onModelChange }) => (
   <div>
-    <label style={LABEL}>Roof Style</label>
+    <label style={LABEL}>Model</label>
     <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
-      {STYLES.map(({ value, label, desc, Icon }) => {
-        const active = style === value;
+      {MODELS.map(({ value, label, desc, Icon }) => {
+        const active = model === value;
         return (
           <button
             key={value}
             role="radio"
             aria-checked={active}
-            onClick={() => onStyleChange(value)}
+            onClick={() => onModelChange(value)}
             style={{
               display: 'flex', flexDirection: 'column',
               alignItems: 'center', justifyContent: 'center',

--- a/frontend/src/components/controls/OptionsSection.jsx
+++ b/frontend/src/components/controls/OptionsSection.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useShedStore } from '../../store/shedStore';
-import { ADD_ON_PRICES } from '../../utils/pricingUtils';
+import { OPTION_PRICES } from '../../utils/pricingUtils';
 
 // ── Primitives ────────────────────────────────────────────────────────────────
 
@@ -92,27 +92,27 @@ function AccordionGroup({ title, selectedCount, children }) {
 
 // ── Main component ─────────────────────────────────────────────────────────────
 
-export const AddOnsSection = () => {
-  const addOns  = useShedStore((s) => s.addOns);
-  const setAddOn = useShedStore((s) => s.setAddOn);
-  const set = (key, cfg) => setAddOn(key, cfg);
+export const OptionsSection = () => {
+  const options  = useShedStore((s) => s.options);
+  const setOption = useShedStore((s) => s.setOption);
+  const set = (key, cfg) => setOption(key, cfg);
 
-  const doorsCount   = [addOns.garageDoor, addOns.additionalDoor, addOns.entryDoor].filter((o) => o.enabled).length;
-  const windowsCount = [addOns.vinylWindows, addOns.octagonWindow, addOns.skylight, addOns.octagonVent].filter((o) => o.enabled).length;
-  const extCount     = [addOns.shutters, addOns.ramp].filter((o) => o.enabled).length;
+  const doorsCount   = [options.garageDoor, options.additionalDoor, options.entryDoor].filter((o) => o.enabled).length;
+  const windowsCount = [options.vinylWindows, options.octagonWindow, options.skylight, options.octagonVent].filter((o) => o.enabled).length;
+  const extCount     = [options.shutters, options.ramp].filter((o) => o.enabled).length;
 
   return (
     <div>
       {/* Doors & Entry */}
       <AccordionGroup title="Doors & Entry" selectedCount={doorsCount}>
         <Checkbox
-          checked={addOns.garageDoor.enabled}
+          checked={options.garageDoor.enabled}
           onChange={(v) => set('garageDoor', { enabled: v })}
           label="Roll-Up Garage Door"
-          price={addOns.garageDoor.size === '8x7' ? ADD_ON_PRICES.garage_door_8x7 : ADD_ON_PRICES.garage_door_6x7}
+          price={options.garageDoor.size === '8x7' ? OPTION_PRICES.garage_door_8x7 : OPTION_PRICES.garage_door_6x7}
         >
-          {addOns.garageDoor.enabled && (
-            <select style={SUB_SELECT} value={addOns.garageDoor.size} onChange={(e) => set('garageDoor', { size: e.target.value })}>
+          {options.garageDoor.enabled && (
+            <select style={SUB_SELECT} value={options.garageDoor.size} onChange={(e) => set('garageDoor', { size: e.target.value })}>
               <option value="6x7">6×7 — $450</option>
               <option value="8x7">8×7 — $500</option>
             </select>
@@ -120,20 +120,20 @@ export const AddOnsSection = () => {
         </Checkbox>
 
         <Checkbox
-          checked={addOns.additionalDoor.enabled}
+          checked={options.additionalDoor.enabled}
           onChange={(v) => set('additionalDoor', { enabled: v })}
           label="Additional Garage Door"
-          price={ADD_ON_PRICES.garage_door_additional}
+          price={OPTION_PRICES.garage_door_additional}
         />
 
         <Checkbox
-          checked={addOns.entryDoor.enabled}
+          checked={options.entryDoor.enabled}
           onChange={(v) => set('entryDoor', { enabled: v })}
           label="36in Pre-Hung Entry Door"
-          price={addOns.entryDoor.type === 'nine_light' ? ADD_ON_PRICES.entry_door_nine_light : ADD_ON_PRICES.entry_door_steel}
+          price={options.entryDoor.type === 'nine_light' ? OPTION_PRICES.entry_door_nine_light : OPTION_PRICES.entry_door_steel}
         >
-          {addOns.entryDoor.enabled && (
-            <select style={SUB_SELECT} value={addOns.entryDoor.type} onChange={(e) => set('entryDoor', { type: e.target.value })}>
+          {options.entryDoor.enabled && (
+            <select style={SUB_SELECT} value={options.entryDoor.type} onChange={(e) => set('entryDoor', { type: e.target.value })}>
               <option value="steel">Steel Panel — $375</option>
               <option value="nine_light">Nine-Light — $425</option>
             </select>
@@ -144,19 +144,19 @@ export const AddOnsSection = () => {
       {/* Windows & Light */}
       <AccordionGroup title="Windows & Light" selectedCount={windowsCount}>
         <Checkbox
-          checked={addOns.vinylWindows.enabled}
+          checked={options.vinylWindows.enabled}
           onChange={(v) => set('vinylWindows', { enabled: v })}
           label="Vinyl Slide Windows"
-          price={ADD_ON_PRICES.window_vinyl_slide * (addOns.vinylWindows.count || 1)}
+          price={OPTION_PRICES.window_vinyl_slide * (options.vinylWindows.count || 1)}
         >
-          {addOns.vinylWindows.enabled && (
+          {options.vinylWindows.enabled && (
             <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-              <select style={SUB_SELECT} value={addOns.vinylWindows.count} onChange={(e) => set('vinylWindows', { count: parseInt(e.target.value, 10) })}>
+              <select style={SUB_SELECT} value={options.vinylWindows.count} onChange={(e) => set('vinylWindows', { count: parseInt(e.target.value, 10) })}>
                 {[1,2,3,4,5,6].map((n) => (
                   <option key={n} value={n}>{n} window{n > 1 ? 's' : ''}</option>
                 ))}
               </select>
-              <select style={SUB_SELECT} value={addOns.vinylWindows.windowSize} onChange={(e) => set('vinylWindows', { windowSize: e.target.value })}>
+              <select style={SUB_SELECT} value={options.vinylWindows.windowSize} onChange={(e) => set('vinylWindows', { windowSize: e.target.value })}>
                 <option value="2x2">24×24</option>
                 <option value="2x3">24×36</option>
                 <option value="3x3">36×36</option>
@@ -166,74 +166,74 @@ export const AddOnsSection = () => {
         </Checkbox>
 
         <Checkbox
-          checked={addOns.octagonWindow.enabled}
+          checked={options.octagonWindow.enabled}
           onChange={(v) => set('octagonWindow', { enabled: v })}
           label="Octagon Gable Window"
-          price={ADD_ON_PRICES.window_octagon}
+          price={OPTION_PRICES.window_octagon}
         />
 
         <Checkbox
-          checked={addOns.skylight.enabled}
+          checked={options.skylight.enabled}
           onChange={(v) => set('skylight', { enabled: v })}
           label="Ridge Skylight"
-          price={ADD_ON_PRICES.skylight_per_ft * (addOns.skylight.runningFt || 0)}
+          price={OPTION_PRICES.skylight_per_ft * (options.skylight.runningFt || 0)}
         >
-          {addOns.skylight.enabled && (
+          {options.skylight.enabled && (
             <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
               <input
                 type="range" min="4" max="20" step="2"
-                value={addOns.skylight.runningFt}
+                value={options.skylight.runningFt}
                 onChange={(e) => set('skylight', { runningFt: parseInt(e.target.value, 10) })}
                 style={{ flex: 1, accentColor: '#3b82f6' }}
               />
               <span style={{ color: '#94a3b8', fontSize: 11, width: 28, textAlign: 'right' }}>
-                {addOns.skylight.runningFt} ft
+                {options.skylight.runningFt} ft
               </span>
             </div>
           )}
         </Checkbox>
 
         <Checkbox
-          checked={addOns.octagonVent.enabled}
+          checked={options.octagonVent.enabled}
           onChange={(v) => set('octagonVent', { enabled: v })}
           label="Vinyl Octagon Gable Vent"
-          price={ADD_ON_PRICES.vent_octagon}
+          price={OPTION_PRICES.vent_octagon}
         />
       </AccordionGroup>
 
       {/* Exterior */}
       <AccordionGroup title="Exterior" selectedCount={extCount}>
         <Checkbox
-          checked={addOns.shutters.enabled}
+          checked={options.shutters.enabled}
           onChange={(v) => set('shutters', { enabled: v })}
           label="15in Vinyl Shutters"
-          price={ADD_ON_PRICES.shutters_per_pair * (addOns.shutters.pairs || 1)}
+          price={OPTION_PRICES.shutters_per_pair * (options.shutters.pairs || 1)}
         >
-          {addOns.shutters.enabled && (
-            <select style={SUB_SELECT} value={addOns.shutters.pairs} onChange={(e) => set('shutters', { pairs: parseInt(e.target.value, 10) })}>
+          {options.shutters.enabled && (
+            <select style={SUB_SELECT} value={options.shutters.pairs} onChange={(e) => set('shutters', { pairs: parseInt(e.target.value, 10) })}>
               {[1,2,3,4].map((n) => (
-                <option key={n} value={n}>{n} pair{n > 1 ? 's' : ''} — ${(ADD_ON_PRICES.shutters_per_pair * n).toLocaleString()}</option>
+                <option key={n} value={n}>{n} pair{n > 1 ? 's' : ''} — ${(OPTION_PRICES.shutters_per_pair * n).toLocaleString()}</option>
               ))}
             </select>
           )}
         </Checkbox>
 
         <Checkbox
-          checked={addOns.ramp.enabled}
+          checked={options.ramp.enabled}
           onChange={(v) => set('ramp', { enabled: v })}
           label="Heavy Duty Treated Ramp"
-          price={addOns.ramp.size === 'large' ? ADD_ON_PRICES.ramp_large : ADD_ON_PRICES.ramp_small}
+          price={options.ramp.size === 'large' ? OPTION_PRICES.ramp_large : OPTION_PRICES.ramp_small}
         >
-          {addOns.ramp.enabled && (
+          {options.ramp.enabled && (
             <div style={{ display: 'flex', gap: 10 }}>
               {[
-                { value: 'small', label: '6–8×4 ft', price: ADD_ON_PRICES.ramp_small },
-                { value: 'large', label: '8–10×4 ft', price: ADD_ON_PRICES.ramp_large },
+                { value: 'small', label: '6–8×4 ft', price: OPTION_PRICES.ramp_small },
+                { value: 'large', label: '8–10×4 ft', price: OPTION_PRICES.ramp_large },
               ].map(({ value, label, price }) => (
                 <label key={value} style={{ display: 'flex', alignItems: 'center', gap: 5, cursor: 'pointer', color: '#94a3b8', fontSize: 12 }}>
                   <input
                     type="radio" name="rampSize" value={value}
-                    checked={addOns.ramp.size === value}
+                    checked={options.ramp.size === value}
                     onChange={() => set('ramp', { size: value })}
                     style={{ accentColor: '#3b82f6' }}
                   />

--- a/frontend/src/components/controls/PriceDisplay.jsx
+++ b/frontend/src/components/controls/PriceDisplay.jsx
@@ -1,14 +1,14 @@
 import { useShedStore } from '../../store/shedStore';
-import { lookupBasePrice, getShedTier, getAddOnLineItems } from '../../utils/pricingUtils';
+import { lookupBasePrice, getShedTier, getOptionLineItems } from '../../utils/pricingUtils';
 
 export const PriceDisplay = () => {
   const width      = useShedStore((s) => s.width);
   const length     = useShedStore((s) => s.length);
   const wallHeight = useShedStore((s) => s.wallHeight);
-  const addOns     = useShedStore((s) => s.addOns);
+  const options     = useShedStore((s) => s.options);
 
   const basePrice  = lookupBasePrice(width, length, wallHeight) ?? 0;
-  const lineItems  = getAddOnLineItems(addOns);
+  const lineItems  = getOptionLineItems(options);
   const total      = basePrice + lineItems.reduce((s, i) => s + i.amount, 0);
   const tier       = getShedTier(wallHeight);
 

--- a/frontend/src/components/shed/extras/Skylight.jsx
+++ b/frontend/src/components/shed/extras/Skylight.jsx
@@ -11,7 +11,7 @@ const PANEL_THICK = 0.04;  // ft
  *   position={[0, wallHeight + roofHeight, 0]} for a gable roof.
  *
  * Props:
- *   runningFt — total ridge length to cover in feet (from addOns.skylight.runningFt)
+ *   runningFt — total ridge length to cover in feet (from options.skylight.runningFt)
  *   numPanels — how many panels to split the run into (default 4)
  */
 export const Skylight = ({ runningFt = 8, numPanels = 4 }) => {

--- a/frontend/src/components/shed/walls/ShedWall.jsx
+++ b/frontend/src/components/shed/walls/ShedWall.jsx
@@ -54,7 +54,7 @@ export const ShedWall = forwardRef(function ShedWall(
   ref
 ) {
   const [modifiedGeometry, setModifiedGeometry] = useState(null);
-  const shuttersEnabled = useShedStore((s) => s.addOns.shutters.enabled);
+  const shuttersEnabled = useShedStore((s) => s.options.shutters.enabled);
 
   const halfW = shedWidth / 2;
   const halfL = shedLength / 2;

--- a/frontend/src/hooks/useDesignPersistence.js
+++ b/frontend/src/hooks/useDesignPersistence.js
@@ -20,7 +20,7 @@ export const useDesignPersistence = () => {
 		setWidth,
 		setLength,
 		setWallHeight,
-		setStyle,
+		setModel,
 		setColor,
 		setRoofColor,
 		setTrimColor,
@@ -33,7 +33,7 @@ export const useDesignPersistence = () => {
 		setFoundationHeight,
 		setFoundationColor,
 		setPorch,
-		setAddOn,
+		setOption,
 		setPrice,
 		clearPlacements,
 		addPlacement,
@@ -85,7 +85,7 @@ export const useDesignPersistence = () => {
 			setWidth(design.width);
 			setLength(design.length);
 			if (design.wallHeight != null) setWallHeight(design.wallHeight);
-			setStyle(design.style);
+			setModel(design.model);
 			setColor(design.color);
 			setRoofColor(design.roofColor);
 			setTrimColor(design.trimColor);
@@ -98,8 +98,8 @@ export const useDesignPersistence = () => {
 			if (design.foundationHeight != null) setFoundationHeight(design.foundationHeight);
 			if (design.foundationColor != null) setFoundationColor(design.foundationColor);
 			if (design.porch != null) setPorch(design.porch);
-			if (design.addOns != null) {
-				Object.entries(design.addOns).forEach(([key, cfg]) => setAddOn(key, cfg));
+			if (design.options != null) {
+				Object.entries(design.options).forEach(([key, cfg]) => setOption(key, cfg));
 			}
 			if (design.price != null) setPrice(design.price);
 			// Restore placements

--- a/frontend/src/pages/reference-match/barn/BarnFoundation.jsx
+++ b/frontend/src/pages/reference-match/barn/BarnFoundation.jsx
@@ -1,4 +1,4 @@
-const SKID_SIZE = 0.333;
+const RUNNER_SIZE = 0.333;
 const SKID_COLOR = '#6B4C2A';
 const DECK_COLOR = '#C8A96E';
 
@@ -13,10 +13,10 @@ export function BarnFoundation({ width = 12, length = 20 }) {
         <meshStandardMaterial color={DECK_COLOR} roughness={0.85} />
       </mesh>
 
-      {/* Pressure-treated skid beams */}
+      {/* Pressure-treated runners */}
       {SKID_XS.map((x) => (
-        <mesh key={x} position={[x, -(SKID_SIZE / 2 + 0.125), 0]} castShadow receiveShadow>
-          <boxGeometry args={[SKID_SIZE, SKID_SIZE, length]} />
+        <mesh key={x} position={[x, -(RUNNER_SIZE / 2 + 0.125), 0]} castShadow receiveShadow>
+          <boxGeometry args={[RUNNER_SIZE, RUNNER_SIZE, length]} />
           <meshStandardMaterial color={SKID_COLOR} roughness={0.8} />
         </mesh>
       ))}

--- a/frontend/src/services/designApi.js
+++ b/frontend/src/services/designApi.js
@@ -45,7 +45,7 @@ apiClient.interceptors.response.use(
  * @param {Object} config - Design configuration object
  * @param {number} config.width - Shed width in feet
  * @param {number} config.length - Shed length in feet
- * @param {string} config.style - Shed style ('Barn' or 'Gable')
+ * @param {string} config.model - Shed Model ('Barn' or 'Gable')
  * @param {string} config.color - Shed color (hex)
  * @param {string} config.roofColor - Roof color (hex)
  * @param {string} config.trimColor - Trim color (hex)
@@ -85,7 +85,7 @@ export const listDesigns = async () => {
 export const validateDesignConfig = (config) => {
 	const errors = [];
 	// Style validation
-	if (!['Barn', 'Gable'].includes(config.style)) {
+	if (!['Barn', 'Gable'].includes(config.model)) {
 		errors.push('Style must be either "Barn" or "Gable"');
 	}
 	// Color validation (basic hex format)

--- a/frontend/src/store/shedStore.js
+++ b/frontend/src/store/shedStore.js
@@ -18,7 +18,7 @@ export const useShedStore = create((set) => ({
 	width: 12,
 	length: 16,
 	wallHeight: 10, // 10 = Standard, 11 = Deluxe, 12 = Special
-	style: 'Gable',
+	model: 'Gable',
 	color: '#D2691E',
 	roofColor: '#8B4513',
 	// Trim and Detail Configuration
@@ -28,7 +28,7 @@ export const useShedStore = create((set) => ({
 	// Material and Texture Configuration
 	sidingTexture: 'T1-11', // 'T1-11', 'smooth'
 	roofMaterial: 'metal', // 'metal', 'shingle'
-	// Gambrel Roof Configuration (when style === 'Gambrel')
+	// Gambrel Roof Configuration (when model === 'Barn')
 	roofLowerPitch: 24, // 24:12 pitch (~63° — classic steep barn eave slope)
 	roofUpperPitch: 6,  // 6:12 pitch (~26.6° — gentle barn ridge slope)
 	// Foundation Configuration
@@ -41,7 +41,7 @@ export const useShedStore = create((set) => ({
 		depth: 6,        // feet the porch extends from the wall
 	},
 	// Add-on options (all disabled by default)
-	addOns: {
+	options: {
 		garageDoor:     { enabled: false, size: '8x7', style: 'sectional' },
 		additionalDoor: { enabled: false, size: '6x7' },
 		entryDoor:      { enabled: false, type: 'steel' }, // 'steel' | 'nine_light'
@@ -70,13 +70,13 @@ export const useShedStore = create((set) => ({
 		const snapped = snapToValidCombo(s.width, s.length, wallHeight);
 		return { width: snapped.width, length: snapped.length, wallHeight: snapped.wallHeight };
 	}),
-	setStyle: (style) => set((s) => ({
-		style,
-		addOns: {
-			...s.addOns,
+	setModel: (model) => set((s) => ({
+		model,
+		options: {
+			...s.options,
 			garageDoor: {
-				...s.addOns.garageDoor,
-				style: style === 'Barn' ? 'rollup' : 'sectional',
+				...s.options.garageDoor,
+				style: model === 'Barn' ? 'rollup' : 'sectional',
 			},
 		},
 	})),
@@ -92,10 +92,10 @@ export const useShedStore = create((set) => ({
 	setRoofUpperPitch: (v) => set({ roofUpperPitch: Math.max(1, Math.min(v, 18)) }),
 	setFoundationHeight: (foundationHeight) => set({ foundationHeight }),
 	setFoundationColor: (foundationColor) => set({ foundationColor }),
-	setAddOn: (key, config) => set((state) => ({
-		addOns: {
-			...state.addOns,
-			[key]: { ...state.addOns[key], ...config },
+	setOption: (key, config) => set((state) => ({
+		options: {
+			...state.options,
+			[key]: { ...state.options[key], ...config },
 		},
 	})),
 	setPorch: (porchConfig) => set((state) => ({
@@ -131,7 +131,7 @@ export const useShedStore = create((set) => ({
 		width: 12,
 		length: 16,
 		wallHeight: 10,
-		style: 'Gable',
+		model: 'Gable',
 		color: '#D2691E',
 		roofColor: '#8B4513',
 		trimColor: '#654321',
@@ -144,7 +144,7 @@ export const useShedStore = create((set) => ({
 		foundationHeight: 1.5,
 		foundationColor: '#8B7355',
 		porch: { enabled: false, wall: 'front', depth: 6 },
-		addOns: {
+		options: {
 			garageDoor:     { enabled: false, size: '8x7', style: 'sectional' },
 			additionalDoor: { enabled: false, size: '6x7' },
 			entryDoor:      { enabled: false, type: 'steel' },
@@ -161,7 +161,7 @@ export const useShedStore = create((set) => ({
 	// Get calculated price (derived state)
 	getPrice: () => {
 		const state = useShedStore.getState();
-		return calculateTotalPrice(state.width, state.length, state.wallHeight, state.addOns);
+		return calculateTotalPrice(state.width, state.length, state.wallHeight, state.options);
 	},
 	// Get full configuration
 	getConfig: () => {
@@ -170,7 +170,7 @@ export const useShedStore = create((set) => ({
 			width: state.width,
 			length: state.length,
 			wallHeight: state.wallHeight,
-			style: state.style,
+			model: state.model,
 			color: state.color,
 			roofColor: state.roofColor,
 			trimColor: state.trimColor,
@@ -184,8 +184,8 @@ export const useShedStore = create((set) => ({
 			foundationColor: state.foundationColor,
 			placements: state.placements,
 			porch: state.porch,
-			addOns: state.addOns,
-			price: calculateTotalPrice(state.width, state.length, state.wallHeight, state.addOns),
+			options: state.options,
+			price: calculateTotalPrice(state.width, state.length, state.wallHeight, state.options),
 		};
 	},
 }));

--- a/frontend/src/store/shedStore.test.js
+++ b/frontend/src/store/shedStore.test.js
@@ -36,11 +36,11 @@ describe('dimensions', () => {
 
 describe('Model', () => {
 	it('fits a Barn with a roll-up door and a Gable with a sectional one', () => {
-		state().setStyle('Barn');
-		expect(state().addOns.garageDoor.style).toBe('rollup');
+		state().setModel('Barn');
+		expect(state().options.garageDoor.style).toBe('rollup');
 
-		state().setStyle('Gable');
-		expect(state().addOns.garageDoor.style).toBe('sectional');
+		state().setModel('Gable');
+		expect(state().options.garageDoor.style).toBe('sectional');
 	});
 });
 

--- a/frontend/src/utils/pricingUtils.js
+++ b/frontend/src/utils/pricingUtils.js
@@ -44,7 +44,7 @@ export const PRICE_TABLE = {
 
 // ─── Add-on price constants ──────────────────────────────────────────────────
 
-export const ADD_ON_PRICES = {
+export const OPTION_PRICES = {
   garage_door_6x7:          450,
   garage_door_8x7:          500,   // $450 base + 2ft × $25/ft
   garage_door_additional:   600,
@@ -150,81 +150,81 @@ export function snapToValidCombo(width, length, wallHeight) {
 
 /**
  * Returns the itemized add-on cost breakdown as an array of { label, amount } lines.
- * Only includes enabled add-ons.
+ * Only includes enabled Options.
  */
-export function getAddOnLineItems(addOns) {
+export function getOptionLineItems(options) {
   const lines = [];
 
-  if (addOns.garageDoor?.enabled) {
-    const key = addOns.garageDoor.size === '8x7' ? 'garage_door_8x7' : 'garage_door_6x7';
-    lines.push({ label: `${addOns.garageDoor.size} Roll-Up Garage Door`, amount: ADD_ON_PRICES[key] });
+  if (options.garageDoor?.enabled) {
+    const key = options.garageDoor.size === '8x7' ? 'garage_door_8x7' : 'garage_door_6x7';
+    lines.push({ label: `${options.garageDoor.size} Roll-Up Garage Door`, amount: OPTION_PRICES[key] });
   }
-  if (addOns.additionalDoor?.enabled) {
-    lines.push({ label: 'Additional Garage Door', amount: ADD_ON_PRICES.garage_door_additional });
+  if (options.additionalDoor?.enabled) {
+    lines.push({ label: 'Additional Garage Door', amount: OPTION_PRICES.garage_door_additional });
   }
-  if (addOns.entryDoor?.enabled) {
-    const key = addOns.entryDoor.type === 'nine_light' ? 'entry_door_nine_light' : 'entry_door_steel';
-    const label = addOns.entryDoor.type === 'nine_light' ? '36in Nine-Light Entry Door' : '36in Steel Entry Door';
-    lines.push({ label, amount: ADD_ON_PRICES[key] });
+  if (options.entryDoor?.enabled) {
+    const key = options.entryDoor.type === 'nine_light' ? 'entry_door_nine_light' : 'entry_door_steel';
+    const label = options.entryDoor.type === 'nine_light' ? '36in Nine-Light Entry Door' : '36in Steel Entry Door';
+    lines.push({ label, amount: OPTION_PRICES[key] });
   }
-  if (addOns.vinylWindows?.enabled) {
-    const count = addOns.vinylWindows.count || 1;
+  if (options.vinylWindows?.enabled) {
+    const count = options.vinylWindows.count || 1;
     lines.push({
       label: `${count}× Vinyl Slide Window${count > 1 ? 's' : ''}`,
-      amount: ADD_ON_PRICES.window_vinyl_slide * count,
+      amount: OPTION_PRICES.window_vinyl_slide * count,
     });
   }
-  if (addOns.octagonWindow?.enabled) {
-    lines.push({ label: 'Octagon Gable Window', amount: ADD_ON_PRICES.window_octagon });
+  if (options.octagonWindow?.enabled) {
+    lines.push({ label: 'Octagon Gable Window', amount: OPTION_PRICES.window_octagon });
   }
-  if (addOns.skylight?.enabled) {
-    const ft = addOns.skylight.runningFt || 0;
-    lines.push({ label: `Ridge Skylight (${ft} ft)`, amount: ADD_ON_PRICES.skylight_per_ft * ft });
+  if (options.skylight?.enabled) {
+    const ft = options.skylight.runningFt || 0;
+    lines.push({ label: `Ridge Skylight (${ft} ft)`, amount: OPTION_PRICES.skylight_per_ft * ft });
   }
-  if (addOns.shutters?.enabled) {
-    const pairs = addOns.shutters.pairs || 1;
+  if (options.shutters?.enabled) {
+    const pairs = options.shutters.pairs || 1;
     lines.push({
       label: `${pairs}× Vinyl Shutter Pair${pairs > 1 ? 's' : ''}`,
-      amount: ADD_ON_PRICES.shutters_per_pair * pairs,
+      amount: OPTION_PRICES.shutters_per_pair * pairs,
     });
   }
-  if (addOns.ramp?.enabled) {
-    const key = addOns.ramp.size === 'large' ? 'ramp_large' : 'ramp_small';
-    const label = addOns.ramp.size === 'large' ? 'Access Ramp (8–10×4ft)' : 'Access Ramp (6–8×4ft)';
-    lines.push({ label, amount: ADD_ON_PRICES[key] });
+  if (options.ramp?.enabled) {
+    const key = options.ramp.size === 'large' ? 'ramp_large' : 'ramp_small';
+    const label = options.ramp.size === 'large' ? 'Access Ramp (8–10×4ft)' : 'Access Ramp (6–8×4ft)';
+    lines.push({ label, amount: OPTION_PRICES[key] });
   }
-  if (addOns.workbench?.enabled) {
-    const ft = addOns.workbench.runningFt || 0;
-    lines.push({ label: `Workbench (${ft} ft)`, amount: ADD_ON_PRICES.workbench_per_ft * ft });
+  if (options.workbench?.enabled) {
+    const ft = options.workbench.runningFt || 0;
+    lines.push({ label: `Workbench (${ft} ft)`, amount: OPTION_PRICES.workbench_per_ft * ft });
   }
-  if (addOns.pegboard?.enabled) {
-    const sheets = addOns.pegboard.sheets || 0;
+  if (options.pegboard?.enabled) {
+    const sheets = options.pegboard.sheets || 0;
     lines.push({
       label: `${sheets}× Pegboard Sheet${sheets === 1 ? '' : 's'}`,
-      amount: ADD_ON_PRICES.pegboard_per_sheet * sheets,
+      amount: OPTION_PRICES.pegboard_per_sheet * sheets,
     });
   }
-  if (addOns.loft?.enabled) {
-    const sqft = addOns.loft.sqft || 0;
-    lines.push({ label: `Loft / Shelving (${sqft} sq ft)`, amount: ADD_ON_PRICES.loft_per_sqft * sqft });
+  if (options.loft?.enabled) {
+    const sqft = options.loft.sqft || 0;
+    lines.push({ label: `Loft / Shelving (${sqft} sq ft)`, amount: OPTION_PRICES.loft_per_sqft * sqft });
   }
-  if (addOns.octagonVent?.enabled) {
-    lines.push({ label: 'Vinyl Octagon Gable Vent', amount: ADD_ON_PRICES.vent_octagon });
+  if (options.octagonVent?.enabled) {
+    lines.push({ label: 'Vinyl Octagon Gable Vent', amount: OPTION_PRICES.vent_octagon });
   }
 
   return lines;
 }
 
-export function calculateAddOnTotal(addOns) {
-  return getAddOnLineItems(addOns).reduce((sum, item) => sum + item.amount, 0);
+export function calculateOptionTotal(options) {
+  return getOptionLineItems(options).reduce((sum, item) => sum + item.amount, 0);
 }
 
 /**
- * Full total price: base lookup + all enabled add-ons.
+ * Full total price: base lookup + all enabled Options.
  */
-export function calculateTotalPrice(width, length, wallHeight, addOns = {}) {
+export function calculateTotalPrice(width, length, wallHeight, options = {}) {
   const base = lookupBasePrice(width, length, wallHeight) ?? 0;
-  return base + calculateAddOnTotal(addOns);
+  return base + calculateOptionTotal(options);
 }
 
 // ─── Formatting helpers (unchanged API) ─────────────────────────────────────

--- a/frontend/src/utils/pricingUtils.test.js
+++ b/frontend/src/utils/pricingUtils.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { lookupBasePrice, getAddOnLineItems, calculateTotalPrice } from './pricingUtils';
+import { lookupBasePrice, getOptionLineItems, calculateTotalPrice } from './pricingUtils';
 
 // Expected prices come from shed-options.md, the catalog of record.
 
@@ -16,36 +16,36 @@ describe('base price', () => {
 describe('Option line items', () => {
 	it('prices an 8x7 roll-up door at the 6x7 price plus two feet of width', () => {
 		// shed-options.md: 6x7 roll-up is $450, "+$25 per foot wider".
-		const [line] = getAddOnLineItems({ garageDoor: { enabled: true, size: '8x7' } });
+		const [line] = getOptionLineItems({ garageDoor: { enabled: true, size: '8x7' } });
 		expect(line.amount).toBe(450 + 2 * 25);
 	});
 
 	it('prices vinyl windows per window', () => {
-		const [line] = getAddOnLineItems({ vinylWindows: { enabled: true, count: 3 } });
+		const [line] = getOptionLineItems({ vinylWindows: { enabled: true, count: 3 } });
 		expect(line.amount).toBe(3 * 275);
 	});
 
 	it('leaves out Options that are not enabled', () => {
-		expect(getAddOnLineItems({ ramp: { enabled: false, size: 'large' } })).toEqual([]);
+		expect(getOptionLineItems({ ramp: { enabled: false, size: 'large' } })).toEqual([]);
 	});
 
 	it('prices a workbench by the running foot', () => {
 		// shed-options.md: 32in heavy duty workbench, $35 per running ft.
-		const [line] = getAddOnLineItems({ workbench: { enabled: true, runningFt: 8 } });
+		const [line] = getOptionLineItems({ workbench: { enabled: true, runningFt: 8 } });
 		expect(line.label).toContain('Workbench');
 		expect(line.amount).toBe(280);
 	});
 
 	it('prices pegboard by the sheet', () => {
 		// shed-options.md: pegboard 4x8 white, $70 per sheet.
-		const [line] = getAddOnLineItems({ pegboard: { enabled: true, sheets: 3 } });
+		const [line] = getOptionLineItems({ pegboard: { enabled: true, sheets: 3 } });
 		expect(line.label).toContain('Pegboard');
 		expect(line.amount).toBe(210);
 	});
 
 	it('prices a loft by the square foot', () => {
 		// shed-options.md: add loft/shelving, $4 per sq ft.
-		const [line] = getAddOnLineItems({ loft: { enabled: true, sqft: 96 } });
+		const [line] = getOptionLineItems({ loft: { enabled: true, sqft: 96 } });
 		expect(line.label).toContain('Loft');
 		expect(line.amount).toBe(384);
 	});


### PR DESCRIPTION
No behaviour change. style -> model, addOns -> options, Skids -> Runners,
across the store, the shed components, pricing, the persistence hook, the
API client and the Go structs.

- `style` was never a roof toggle: a Model carries the roof profile, wall
  height, stud length and trim set as one bundle. The renamed axis is
  `model: 'Gable' | 'Barn'`. The 110 JSX `style=` props and the separate
  `garageDoor.style` ('sectional' | 'rollup') are untouched.
- StyleSection -> ModelSection, AddOnsSection -> OptionsSection,
  common/Skids.jsx -> common/Runners.jsx.
- Breaking API change: the Design payload now sends `model` and `options`
  instead of `style` and `addOns`. Free now, while designs live in a map
  that empties on restart; expensive once #12 lands.
- User-facing copy follows the glossary: the "Add-Ons" tab is now
  "Options" and "Roof Style" is now "Model".

Verified: 34 JS tests and 5 Go tests green, production build clean, lint
unchanged at 11 pre-existing errors, gofmt and go vet clean. Also driven
in a browser, because none of the above mounts React - which is how the
tab ids were caught: they had been renamed while the `activeTab ===`
comparisons still used the old strings, leaving Model and Options blank.

Closes #1.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
