### PR TITLE
Nail the corner boards onto the siding, and dispose the geometries R3F will not

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,8 @@ outside React use `useShedStore.getState()`. Never mutate state directly — eve
 through an action.
 
 Defaults: `width: 12`, `length: 16`, `tier: 'Standard'`, `model: 'Gable'`,
-`sidingTexture: 'T1-11'`, `roofMaterial: 'metal'`, `roofLowerPitch: 12`, `roofUpperPitch: 4`.
+`sidingTexture: 'T1-11'`, `roofMaterial: 'metal'`, `roofLowerPitch: 20`, `roofUpperPitch: 4`
+(both from the `GAMBREL_*` constants, never typed as literals).
 
 There is no `wallHeight` in the store. The wall is a Model constant in `utils/modelSpec.js`
 (85in Barn, 88.5in Gable) and the Peak Height is derived from it for display only. The
@@ -95,8 +96,20 @@ Trim is per Model and deliberately not shared — `GableTrim` has corner boards,
 rake boards; `BarnTrim` has **corner boards only**. ADR-0006 says the Barn also has fascia; the
 code disagrees, and which one matches the product is settled against the Reference Photos in #5
 and #6, not by reading the component (issue #22). The Trim Set is part of the Model bundle, so
-treat it as a product question. Trim stock is `0.333 ft` (~4in); roof overhang at the eave is
-`0.5 ft`.
+treat it as a product question. Roof overhang at the eave is `0.5 ft`.
+
+A corner board, though, is the same board on both, and **`cornerBoards` in
+`utils/trimGeometry.js` is the only place corner positions are worked out** — the trim
+counterpart to `openingTransform` (ADR-0011). Both components ask it; neither computes.
+
+Trim stock has two numbers, and they are not the same number: `TRIM_WIDTH` is the face you see
+(`0.333 ft`, 4in) and `TRIM_THICKNESS` is how far the board stands off the siding (`0.0625 ft`,
+a dressed 1x). They used to be one value, which is what buried every corner board inside the
+wall with its faces exactly coplanar — nothing decided which surface won and each board rendered
+as hatched noise (issue #31). A corner board is nailed **on** the siding; the two boards at a
+corner lap rather than butt, so the front or back one runs past to cover the side board's end
+grain. The 4in face is what both components have always defaulted to; the Reference Photos
+measure the real stock nearer 5.5in, and issue #22 settles that.
 
 ### CSG (cutting openings)
 
@@ -250,6 +263,7 @@ under test is non-React.
 | Placement rules | `utils/placementValidator.test.js` |
 | Cutting openings | `utils/wallOpenings.test.js` |
 | Walls and Placement routing | `utils/wallSides.test.js` |
+| Trim placement | `utils/trimGeometry.test.js` |
 | Store behaviour | `store/shedStore.test.js` |
 | HTTP API | `backend/main_test.go` |
 
@@ -341,6 +355,7 @@ frontend/src/
   utils/design.js                 overlay a fixed Design on the store's (ADR-0012)
   utils/wallOpenings.js           CSG: cut Openings out of a wall (Brush, local space)
   utils/wallSides.js              the four walls, and routing Placements onto them
+  utils/trimGeometry.js           where the trim boards sit; corner positions for both Models
   utils/pricingUtils.js           catalog and Option line items
   services/designApi.js           axios client
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -280,6 +280,11 @@ Two rules that matter more than coverage:
 - Clone geometry before a CSG operation rather than mutating the original.
 - Dispose geometries and materials you create outside the JSX tree — shader factories return fresh
   `ShaderMaterial` configs and React Three Fiber will not clean them up (ADR-0002).
+- **A geometry that reaches a mesh through `<primitive>` belongs to whoever built it.** R3F
+  deliberately never disposes a primitive's object, so a `useMemo` that builds one needs
+  `useEffect(() => () => geometry.dispose(), [geometry])` beside it. Without that, every distinct
+  size the store passes through leaves its buffers on the GPU (issue #20). A `<boxGeometry>` or
+  `<shaderMaterial args={...}>` element is *not* a primitive and is cleaned up for you.
 - Wrap 3D subtrees in `<Suspense>`; use `<OrbitControls>` from `@react-three/drei`.
 - Prefer store state over component state for anything the 3D view reads.
 

--- a/frontend/src/components/shed/roofs/GableEnd.jsx
+++ b/frontend/src/components/shed/roofs/GableEnd.jsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useEffect } from 'react';
 import * as THREE from 'three';
 import { makeSidingShader } from '../../../utils/shaders';
 import { OctagonWindow } from '../openings/OctagonWindow';
@@ -36,6 +36,12 @@ export const GableEnd = ({
     geo.computeVertexNormals();
     return geo;
   }, [halfWidth, roofHeight]);
+
+  // Same lifetime problem as ShedWall's slab: this reaches the mesh through a
+  // <primitive>, which R3F never disposes, so the memo owns it. Two triangles
+  // times three buffers leaked on every width the customer passed through
+  // (issue #20).
+  useEffect(() => () => geometry.dispose(), [geometry]);
 
   const sidingShader = useMemo(
     () => makeSidingShader(color, sidingTexture),

--- a/frontend/src/components/shed/trim/BarnTrim.jsx
+++ b/frontend/src/components/shed/trim/BarnTrim.jsx
@@ -1,35 +1,33 @@
+import { cornerBoards } from '../../../utils/trimGeometry';
+
 /**
- * BarnTrim — style-specific trim for barn (gambrel) sheds.
+ * BarnTrim — the trim set that comes with the Barn Model.
  * Renders 4 corner boards only.
  * No eave fascia (covered by roof overhang), no knuckle boards (gambrel break
  * is a roof profile feature, not a side-wall trim board).
  * Only imported by BarnShed — never shared with GableShed.
+ *
+ * Whether the Barn really has no fascia is a product question, open in #22.
+ *
+ * Corner positions come from `cornerBoards`, not from this file: they used to
+ * be worked out here and in GableTrim separately, and both copies buried the
+ * board inside the siding (issue #31).
  */
 export const BarnTrim = ({
   shedWidth,
   shedLength,
   wallHeight,
   trimColor,
-  trimWidth = 0.333,
+  trimWidth,
 }) => {
-  const halfW = shedWidth / 2;
-  const halfL = shedLength / 2;
-  const tw    = trimWidth;
-
   const TRIM_MAT = { color: trimColor, roughness: 0.45, metalness: 0.1 };
-
-  const corners = [
-    [-(halfW - tw / 2),  halfL - tw / 2],
-    [+(halfW - tw / 2),  halfL - tw / 2],
-    [-(halfW - tw / 2), -(halfL - tw / 2)],
-    [+(halfW - tw / 2), -(halfL - tw / 2)],
-  ];
+  const corners = cornerBoards(shedWidth, shedLength, wallHeight, { trimWidth });
 
   return (
     <group name="barnTrim">
-      {corners.map(([cx, cz], i) => (
-        <mesh key={`corner-${i}`} position={[cx, wallHeight / 2, cz]} castShadow receiveShadow>
-          <boxGeometry args={[tw, wallHeight, tw]} />
+      {corners.map(({ corner, face, position, size }) => (
+        <mesh key={`corner-${corner}-${face}`} position={position} castShadow receiveShadow>
+          <boxGeometry args={size} />
           <meshStandardMaterial {...TRIM_MAT} />
         </mesh>
       ))}

--- a/frontend/src/components/shed/trim/GableTrim.jsx
+++ b/frontend/src/components/shed/trim/GableTrim.jsx
@@ -1,7 +1,13 @@
+import { cornerBoards, TRIM_WIDTH } from '../../../utils/trimGeometry';
+
 /**
- * GableTrim — style-specific trim for gable sheds.
+ * GableTrim — the trim set that comes with the Gable Model.
  * Renders: 4 corner boards + 2 eave fascia boards + 4 rake boards.
  * Only imported by GableShed — never shared with BarnShed.
+ *
+ * Corner positions come from `cornerBoards`, shared with BarnTrim — a corner
+ * board is the same board on both Models. What differs is everything else
+ * here, which is the Model's trim set and stays per-Model on purpose.
  */
 export const GableTrim = ({
   shedWidth,
@@ -9,7 +15,7 @@ export const GableTrim = ({
   wallHeight,
   roofHeight = 4,
   trimColor,
-  trimWidth = 0.333,
+  trimWidth = TRIM_WIDTH,
   overhangEave = 0.5,
 }) => {
   const halfW = shedWidth / 2;
@@ -21,13 +27,7 @@ export const GableTrim = ({
 
   const TRIM_MAT = { color: trimColor, roughness: 0.45, metalness: 0.1 };
 
-  // Corner board X/Z positions (4 corners)
-  const corners = [
-    [-(halfW - tw / 2),  halfL - tw / 2],
-    [+(halfW - tw / 2),  halfL - tw / 2],
-    [-(halfW - tw / 2), -(halfL - tw / 2)],
-    [+(halfW - tw / 2), -(halfL - tw / 2)],
-  ];
+  const corners = cornerBoards(shedWidth, shedLength, wallHeight, { trimWidth });
 
   // Rake board configs: [centerX, centerZ, rotZ]
   const rakes = [
@@ -40,9 +40,9 @@ export const GableTrim = ({
   return (
     <group name="gableTrim">
       {/* Corner boards */}
-      {corners.map(([cx, cz], i) => (
-        <mesh key={`corner-${i}`} position={[cx, wallHeight / 2, cz]} castShadow receiveShadow>
-          <boxGeometry args={[tw, wallHeight, tw]} />
+      {corners.map(({ corner, face, position, size }) => (
+        <mesh key={`corner-${corner}-${face}`} position={position} castShadow receiveShadow>
+          <boxGeometry args={size} />
           <meshStandardMaterial {...TRIM_MAT} />
         </mesh>
       ))}

--- a/frontend/src/components/shed/walls/ShedWall.jsx
+++ b/frontend/src/components/shed/walls/ShedWall.jsx
@@ -56,6 +56,15 @@ export const ShedWall = forwardRef(function ShedWall(
     [localGeomWidth, wallHeight]
   );
 
+  // A wall with no Openings renders this slab, and it reaches the mesh through
+  // the same <primitive> the cut geometry does — so the memo owns its lifetime
+  // too. Without this, every distinct size the store passes through leaves a
+  // BoxGeometry behind with its GPU buffers still allocated: four per width the
+  // customer drags past, never collected (issue #20). The cleanup runs after
+  // the commit that swapped the geometry, so the mesh is already pointing at
+  // the new one by the time the old is disposed.
+  useEffect(() => () => baseGeometry.dispose(), [baseGeometry]);
+
   // World position + rotation for this wall side
   const [position, rotation] = useMemo(() => {
     switch (side) {

--- a/frontend/src/utils/trimGeometry.js
+++ b/frontend/src/utils/trimGeometry.js
@@ -1,0 +1,87 @@
+/**
+ * Where the trim boards sit on a shed.
+ *
+ * The trim counterpart to `openingTransform` (ADR-0011): one place works out
+ * the coordinates, so the components cannot drift apart. `BarnTrim` and
+ * `GableTrim` render different trim sets — that difference is part of the
+ * Model bundle and stays in the components — but a corner board is a corner
+ * board on both, and both ask here for it.
+ *
+ * Everything is in shed space, the same space the walls are placed in: the
+ * outer face of the front siding is at `+length / 2`, of the right siding at
+ * `+width / 2`, and the floor is y = 0.
+ */
+
+/**
+ * The face width of a trim board in feet — what you see looking at it.
+ *
+ * 4in, which is what both trim components have always defaulted to. The
+ * Reference Photos measure the real stock at nearer 5.5in (1x6); that is a
+ * product question and issue #22 settles it.
+ */
+export const TRIM_WIDTH = 0.333;
+
+/**
+ * How thick the stock is in feet — how far a board stands off the siding.
+ *
+ * 3/4in, a dressed 1x board. Width and thickness used to be the same number,
+ * which is what made "proud of the wall" and "as wide as a board" impossible
+ * to ask for separately.
+ */
+export const TRIM_THICKNESS = 0.0625;
+
+/**
+ * The corner boards, two per corner.
+ *
+ * A corner board is nailed **on** the siding, not let into it. Both boards
+ * used to be centred on the wall plane, which buried them in the wall with
+ * their outer faces exactly coplanar with the siding — nothing decided which
+ * surface won, so each board rendered as a strip of hatched noise that changed
+ * with the camera (issue #31).
+ *
+ * The two boards at a corner lap rather than butt: the front or back board
+ * runs past the corner to cover the end grain of the side board, which is how
+ * the joint is actually built and leaves no notch at the corner.
+ *
+ * @param {number} shedWidth - feet, across the front
+ * @param {number} shedLength - feet, front to back
+ * @param {number} wallHeight - feet, floor to eave
+ * @param {{trimWidth?: number, trimThickness?: number}} [stock]
+ * @returns {Array<{corner: string, face: string, position: number[], size: number[]}>}
+ */
+export function cornerBoards(shedWidth, shedLength, wallHeight, stock = {}) {
+	const { trimWidth = TRIM_WIDTH, trimThickness = TRIM_THICKNESS } = stock;
+
+	const halfW = shedWidth / 2;
+	const halfL = shedLength / 2;
+	const w = trimWidth;
+	const t = trimThickness;
+	const y = wallHeight / 2;
+
+	// sx picks the right (+1) or left (-1) wall, sz the front (+1) or back (-1).
+	const quadrants = [
+		{ corner: 'front-right', sx: +1, sz: +1, face: 'right', endFace: 'front' },
+		{ corner: 'front-left', sx: -1, sz: +1, face: 'left', endFace: 'front' },
+		{ corner: 'back-right', sx: +1, sz: -1, face: 'right', endFace: 'back' },
+		{ corner: 'back-left', sx: -1, sz: -1, face: 'left', endFace: 'back' },
+	];
+
+	return quadrants.flatMap(({ corner, sx, sz, face, endFace }) => [
+		// On the side wall: thickness out in X, face width running back in Z,
+		// stopping where the front or back siding takes over.
+		{
+			corner,
+			face,
+			position: [sx * (halfW + t / 2), y, sz * (halfL - w / 2)],
+			size: [t, wallHeight, w],
+		},
+		// On the front or back wall: face width running across X, far enough
+		// past the corner to lap the side board's outer face at halfW + t.
+		{
+			corner,
+			face: endFace,
+			position: [sx * (halfW + (t - w) / 2), y, sz * (halfL + t / 2)],
+			size: [w + t, wallHeight, t],
+		},
+	]);
+}

--- a/frontend/src/utils/trimGeometry.test.js
+++ b/frontend/src/utils/trimGeometry.test.js
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { cornerBoards, TRIM_THICKNESS, TRIM_WIDTH } from './trimGeometry';
+
+// A 12x20 shed. The wall outer faces land on round numbers, which is what
+// makes the expected values below checkable by hand: ShedWall puts the front
+// wall's outer face at z = length/2 and the right wall's at x = width/2.
+const WIDTH = 12;
+const LENGTH = 20;
+const WALL_HEIGHT = 8;
+
+const halfW = WIDTH / 2;   // 6.0 — the plane the left/right siding sits on
+const halfL = LENGTH / 2;  // 10.0 — the plane the front/back siding sits on
+
+const boards = () => cornerBoards(WIDTH, LENGTH, WALL_HEIGHT);
+
+/** Axis-aligned bounds of a board, as [min, max] per axis. */
+const boundsOf = ({ position, size }) =>
+	position.map((c, axis) => [c - size[axis] / 2, c + size[axis] / 2]);
+
+/**
+ * How much of a board lies inside the wall volume.
+ *
+ * The wall envelope is the box the siding encloses: x and z out to the outer
+ * faces, floor to eave. A board nailed onto the siding touches this box and
+ * never enters it, so the overlap is zero. Touching faces overlap by zero
+ * width, which is why this measures volume and not intersection.
+ */
+const volumeInsideWalls = (board) => {
+	const envelope = [[-halfW, halfW], [0, WALL_HEIGHT], [-halfL, halfL]];
+	return boundsOf(board).reduce((volume, [lo, hi], axis) => {
+		const [eLo, eHi] = envelope[axis];
+		return volume * Math.max(0, Math.min(hi, eHi) - Math.max(lo, eLo));
+	}, 1);
+};
+
+describe('cornerBoards', () => {
+	it('trims all four corners on both of the faces that meet there', () => {
+		const all = boards();
+		expect(all).toHaveLength(8);
+
+		const byCorner = {};
+		for (const board of all) {
+			byCorner[board.corner] = byCorner[board.corner] ?? [];
+			byCorner[board.corner].push(board.face);
+		}
+
+		expect(Object.keys(byCorner).sort()).toEqual([
+			'back-left', 'back-right', 'front-left', 'front-right',
+		]);
+		// Each corner is where two walls meet, and both need covering.
+		expect(byCorner['front-right'].sort()).toEqual(['front', 'right']);
+		expect(byCorner['front-left'].sort()).toEqual(['front', 'left']);
+		expect(byCorner['back-right'].sort()).toEqual(['back', 'right']);
+		expect(byCorner['back-left'].sort()).toEqual(['back', 'left']);
+	});
+
+	it('keeps every board out of the wall volume', () => {
+		// Issue #31: the boards were buried in the siding with their outer
+		// faces exactly coplanar, so nothing decided which surface won and each
+		// board rendered as hatched noise.
+		for (const board of boards()) {
+			expect(volumeInsideWalls(board)).toBeCloseTo(0, 10);
+		}
+	});
+
+	it('lands each board against the siding it is nailed to', () => {
+		// Proud of the wall, but touching it — a gap would show daylight.
+		for (const board of boards()) {
+			const [[minX, maxX], , [minZ, maxZ]] = boundsOf(board);
+			if (board.face === 'front') expect(minZ).toBeCloseTo(halfL, 10);
+			if (board.face === 'back') expect(maxZ).toBeCloseTo(-halfL, 10);
+			if (board.face === 'right') expect(minX).toBeCloseTo(halfW, 10);
+			if (board.face === 'left') expect(maxX).toBeCloseTo(-halfW, 10);
+		}
+	});
+
+	it('laps the face board over the side board so the corner has no gap', () => {
+		const all = boards();
+		const front = all.find((b) => b.corner === 'front-right' && b.face === 'front');
+		const side = all.find((b) => b.corner === 'front-right' && b.face === 'right');
+
+		// Worked out from the shed rather than from the function: the right
+		// wall's siding is at x = 6.0, so a board on it stands proud to
+		// 6.0 + 0.0625. The front board has to reach that same x to hide the
+		// side board's end grain, and it starts a board's width back from the
+		// corner at 6.0 - 0.333.
+		const [[frontMinX, frontMaxX]] = boundsOf(front);
+		expect(frontMaxX).toBeCloseTo(halfW + TRIM_THICKNESS, 10);
+		expect(frontMinX).toBeCloseTo(halfW - TRIM_WIDTH, 10);
+
+		const [[sideMinX, sideMaxX], , [sideMinZ, sideMaxZ]] = boundsOf(side);
+		expect(sideMaxX).toBeCloseTo(halfW + TRIM_THICKNESS, 10);
+		expect(sideMinX).toBeCloseTo(halfW, 10);
+		// The side board stops at the front siding, where the front board takes over.
+		expect(sideMaxZ).toBeCloseTo(halfL, 10);
+		expect(sideMinZ).toBeCloseTo(halfL - TRIM_WIDTH, 10);
+	});
+
+	it('runs the boards floor to eave', () => {
+		for (const board of boards()) {
+			const [, [minY, maxY]] = boundsOf(board);
+			expect(minY).toBeCloseTo(0, 10);
+			expect(maxY).toBeCloseTo(WALL_HEIGHT, 10);
+		}
+	});
+});


### PR DESCRIPTION
Closes #31, closes #20.

## #31 — corner boards Z-fight

The boards were centred on the wall plane, so each sat *inside* the wall with its outer faces exactly coplanar with the siding. Nothing decides which of two coincident surfaces wins, so every board rendered as a strip of hatched noise that changed with the camera. Both Models.

The root cause was one number doing two jobs: trim width and trim thickness were the same value, so "as wide as a board" and "proud of the siding by a board's thickness" were the same request. They are now `TRIM_WIDTH` (4in face, unchanged) and `TRIM_THICKNESS` (3/4in).

Positions move to `cornerBoards()` in a new `utils/trimGeometry.js` — the trim counterpart to `openingTransform` (ADR-0011). `BarnTrim` and `GableTrim` each had their own copy of the corner formula and both copies were wrong the same way; neither computes now.

The two boards at a corner lap rather than butt, so the front or back one covers the side board's end grain.

**On the tests:** they measure how much of each board lies inside the wall volume — the bug stated as a quantity rather than as a formula, so it cannot pass by construction. Reverted to the old placement first and confirmed exactly the three tests that describe the bug go red.

**Still open:** #22 measures the real trim stock at ~5.5in against the reference photos. That is now a one-line change to `TRIM_WIDTH` that both Models pick up.

## #20 — leaked geometry, plus one the issue did not know about

A geometry attached through `<primitive>` is never disposed by R3F — the reconciler skips primitives deliberately. Both `ShedWall`'s uncut slab and `GableEnd`'s triangle are built in a `useMemo` and reach the mesh that way.

`GableEnd` is not in the issue. It turned up while measuring: after fixing the walls the sweep still leaked exactly 6 buffers per width change, which is two triangles times three attributes.

No seam here avoids mounting React, so this was verified by counting `createBuffer` against `deleteBuffer` over a fixed sweep of eight size changes:

| | created | deleted | leaked |
|---|---|---|---|
| before | 548 | 380 | **168** |
| ShedWall only | 548 | 500 | **48** |
| both | 548 | 548 | **0** |

Zero holds on two consecutive passes, so it is steady state rather than a slower leak, and the Barn path reaches zero too. Allocation counts are identical across all three — the fix changes only what is released.

## Verification

98 frontend tests, lint unchanged, build clean. Both Models checked on screen: corner boards render as clean lapped boards where they were hatched noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)