### PR TITLE
Validate the Design and its Placements before saving, on both sides

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,12 +137,19 @@ on restart**, and `GET /api/designs` returns everything to anyone (issue #12).
 
 | Route | Behaviour |
 |---|---|
-| `POST /api/save-design` | Validates the combination and the Model, computes the Quote, returns 201 with a UUID |
+| `POST /api/save-design` | Validates the combination, the Model and every Placement, computes the Quote, returns 201 with a UUID |
 | `GET /api/design/:id` | One Design, or 404 |
 | `GET /api/designs` | Every stored Design |
 
 `newRouter()` builds the router so tests can drive it with `httptest`; `main()` only serves it.
 CORS is wide open (`*`).
+
+A Design is stored exactly as it arrives and handed straight back to the renderer on load, so
+`validatePlacements` refuses any Placement that could not be drawn. **`Placement`'s coordinate
+fields are `*float64` on purpose**: a non-finite number serializes as `null`, and Go decodes
+`null` into a plain `float64` as `0` without complaint — the Opening would be accepted and
+quietly moved to the corner of its wall rather than refused (issue #19). It mirrors
+`validateDesignConfig` in `services/designApi.js`; neither may be the weaker of the two.
 
 ## Pricing and the Quote
 
@@ -251,6 +258,7 @@ under test is non-React.
 | Cutting openings | `utils/wallOpenings.test.js` |
 | Walls and Placement routing | `utils/wallSides.test.js` |
 | Store behaviour | `store/shedStore.test.js` |
+| The save gate | `services/designApi.test.js` |
 | HTTP API | `backend/main_test.go` |
 
 Two rules that matter more than coverage:

--- a/backend/main.go
+++ b/backend/main.go
@@ -58,15 +58,66 @@ func lookupBasePrice(width, length int, tier string) (float64, bool) {
 }
 
 // Placement represents a door or window placement on the shed.
+//
+// The coordinates are pointers so that "absent" is distinguishable from
+// "zero". A client that produced a non-finite coordinate serializes it as
+// `null`, which decodes into a plain float64 as 0 without complaint — the
+// Opening would be accepted and quietly moved to the bottom-left corner of
+// its wall instead of being refused (issue #19). Once validated they are
+// always non-nil, so the stored JSON is unchanged.
 type Placement struct {
-	ID          string  `json:"id"`
-	Type        string  `json:"type"` // "door", "window", "garage_door", "swing_barn_door", "entry_door"
-	Wall        string  `json:"wall"` // "front", "back", "left", "right"
-	NormalizedX float64 `json:"normalizedX"`
-	NormalizedY float64 `json:"normalizedY"`
-	Width       float64 `json:"width"`
-	Height      float64 `json:"height"`
-	RotationZ   float64 `json:"rotationZ,omitempty"`
+	ID          string   `json:"id"`
+	Type        string   `json:"type"` // "door", "window", "garage_door", "swing_barn_door", "entry_door"
+	Wall        string   `json:"wall"` // "front", "back", "left", "right"
+	NormalizedX *float64 `json:"normalizedX"`
+	NormalizedY *float64 `json:"normalizedY"`
+	Width       *float64 `json:"width"`
+	Height      *float64 `json:"height"`
+	RotationZ   float64  `json:"rotationZ,omitempty"`
+}
+
+// wallSides are the four walls every Model renders (ADR-0010).
+var wallSides = map[string]bool{"front": true, "back": true, "left": true, "right": true}
+
+// validatePlacements rejects any Placement the renderer could not draw.
+//
+// This mirrors validateDesignConfig in the frontend. The client check is the
+// only other one there is, so this must not be the weaker of the two: a
+// Design is stored exactly as it arrives and is handed straight back to the
+// renderer on load.
+func validatePlacements(placements []*Placement) error {
+	for i, p := range placements {
+		if p == nil {
+			return fmt.Errorf("placement %d is missing", i)
+		}
+		where := p.ID
+		if where == "" {
+			where = fmt.Sprintf("index %d", i)
+		}
+		for name, value := range map[string]*float64{
+			"normalizedX": p.NormalizedX,
+			"normalizedY": p.NormalizedY,
+		} {
+			if value == nil {
+				return fmt.Errorf("placement %s has no %s", where, name)
+			}
+			if *value < 0 || *value > 1 {
+				return fmt.Errorf("placement %s has %s outside its wall", where, name)
+			}
+		}
+		for name, value := range map[string]*float64{
+			"width":  p.Width,
+			"height": p.Height,
+		} {
+			if value == nil || *value <= 0 {
+				return fmt.Errorf("placement %s has an invalid %s", where, name)
+			}
+		}
+		if !wallSides[p.Wall] {
+			return fmt.Errorf("placement %s names a wall the shed does not have: %q", where, p.Wall)
+		}
+	}
+	return nil
 }
 
 // OptionConfig holds the client-supplied add-on state.
@@ -215,6 +266,11 @@ func saveDesign(c *gin.Context) {
 
 	if input.Model != "Gable" && input.Model != "Barn" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Model must be 'Gable' or 'Barn'"})
+		return
+	}
+
+	if err := validatePlacements(input.Placements); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/backend/main_test.go
+++ b/backend/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -107,5 +108,76 @@ func TestWideSizesAreDeluxeOnly(t *testing.T) {
 	rec, _ := post(t, `{"width":16,"length":24,"tier":"Standard","model":"Barn"}`)
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("want 400 for a 16 wide Standard, got %d", rec.Code)
+	}
+}
+
+// A Placement is stored exactly as the client sends it, so the server is the
+// last chance to reject one that cannot be rendered (issue #19).
+//
+// The coordinates matter more than they look. A client that produced a NaN
+// serializes it as `null`, because that is what JSON.stringify does with a
+// non-finite number — and Go decodes `null` into a float64 as 0, not as an
+// error. Without an explicit presence check the Opening is accepted and lands
+// in the bottom-left corner of its wall rather than being refused.
+func TestRejectsPlacementWithMissingCoordinate(t *testing.T) {
+	design := `{"width":12,"length":16,"tier":"Standard","model":"Gable","placements":[%s]}`
+
+	cases := map[string]string{
+		"null X":   `{"id":"a","type":"window","wall":"front","normalizedX":null,"normalizedY":0.5,"width":3,"height":3}`,
+		"null Y":   `{"id":"a","type":"window","wall":"front","normalizedX":0.5,"normalizedY":null,"width":3,"height":3}`,
+		"absent X": `{"id":"a","type":"window","wall":"front","normalizedY":0.5,"width":3,"height":3}`,
+		"absent Y": `{"id":"a","type":"window","wall":"front","normalizedX":0.5,"width":3,"height":3}`,
+	}
+
+	for name, placement := range cases {
+		t.Run(name, func(t *testing.T) {
+			rec, _ := post(t, fmt.Sprintf(design, placement))
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("want 400 for a Placement with a %s, got %d: %s", name, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestRejectsUnrenderablePlacement(t *testing.T) {
+	design := `{"width":12,"length":16,"tier":"Standard","model":"Gable","placements":[%s]}`
+
+	cases := map[string]string{
+		"X past the end of the wall": `{"id":"a","type":"window","wall":"front","normalizedX":1.4,"normalizedY":0.5,"width":3,"height":3}`,
+		"Y below the floor":          `{"id":"a","type":"window","wall":"front","normalizedX":0.5,"normalizedY":-0.2,"width":3,"height":3}`,
+		"no width":                   `{"id":"a","type":"window","wall":"front","normalizedX":0.5,"normalizedY":0.5,"width":0,"height":3}`,
+		"negative height":            `{"id":"a","type":"window","wall":"front","normalizedX":0.5,"normalizedY":0.5,"width":3,"height":-3}`,
+		"a wall the shed lacks":      `{"id":"a","type":"window","wall":"roof","normalizedX":0.5,"normalizedY":0.5,"width":3,"height":3}`,
+	}
+
+	for name, placement := range cases {
+		t.Run(name, func(t *testing.T) {
+			rec, _ := post(t, fmt.Sprintf(design, placement))
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("want 400 for a Placement with %s, got %d: %s", name, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+// The guard must not refuse Openings the configurator can legitimately make:
+// 0 is the floor and the left edge, 1 is the eave and the right edge.
+func TestAcceptsPlacementAtTheEdgesOfItsWall(t *testing.T) {
+	rec, saved := post(t, `{"width":12,"length":16,"tier":"Standard","model":"Gable","placements":[
+		{"id":"a","type":"window","wall":"front","normalizedX":0,"normalizedY":1,"width":3,"height":3},
+		{"id":"b","type":"door","wall":"left","normalizedX":1,"normalizedY":0,"width":3,"height":6.67}
+	]}`)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("want 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if len(saved.Placements) != 2 {
+		t.Fatalf("want both Placements stored, got %d", len(saved.Placements))
+	}
+	if got := saved.Placements[0].NormalizedX; got == nil || *got != 0 {
+		t.Errorf("want normalizedX 0 echoed back, got %v", got)
+	}
+	if got := saved.Placements[1].NormalizedY; got == nil || *got != 0 {
+		t.Errorf("want normalizedY 0 echoed back, got %v", got)
 	}
 }

--- a/frontend/src/services/designApi.js
+++ b/frontend/src/services/designApi.js
@@ -6,6 +6,8 @@
  */
 
 import axios from 'axios';
+import { isValidCombo, TIERS } from '../utils/pricingUtils';
+import { WALL_SIDES } from '../utils/wallSides';
 
 // API Configuration
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080/api';
@@ -78,17 +80,39 @@ export const listDesigns = async () => {
 };
 
 /**
- * Helper function to validate design configuration before saving
+ * The gate `useDesignPersistence.save()` runs before POSTing a Design.
+ *
+ * This is the only validation a Placement gets. The server checks the
+ * combination and the Model and then stores whatever `placements` array it
+ * was handed, so this check must not be the weaker of the two (issue #19).
+ *
+ * The hazard is a non-finite coordinate. `JSON.stringify(NaN)` is `"null"`,
+ * so such a Placement saves clean and comes back on load as an Opening whose
+ * cut box is at `null` — a wall that silently fails to cut its hole, or that
+ * throws inside the evaluator and logs to a console nobody is reading.
+ *
+ * What this deliberately does not check:
+ * - **whether an Opening fits its wall.** `validatePlacement` in
+ *   `utils/placementValidator.js` owns that, and it is a different question:
+ *   this asks whether the data is well-formed, that asks whether the shed is
+ *   buildable. Duplicating it here would give two answers to one question.
+ * - **`price`.** The server recomputes it and ignores whatever the client
+ *   sent (ADR-0008), so there is nothing here worth guarding.
+ *
+ * Every problem is reported, not just the first: a customer fixing one field
+ * at a time because the gate only ever names one is worse than a long list.
+ *
  * @param {Object} config - Design configuration to validate
- * @returns {Object} Validation result {isValid: boolean, errors: string[]}
+ * @returns {{isValid: boolean, errors: string[]}}
  */
 export const validateDesignConfig = (config) => {
 	const errors = [];
-	// Style validation
+
 	if (!['Barn', 'Gable'].includes(config.model)) {
-		errors.push('Style must be either "Barn" or "Gable"');
+		errors.push('Model must be either "Barn" or "Gable"');
 	}
-	// Color validation (basic hex format)
+
+	// Colours are optional; an invalid one is not.
 	const hexColorRegex = /^#[0-9A-Fa-f]{6}$/;
 	if (config.color && !hexColorRegex.test(config.color)) {
 		errors.push('Invalid shed color format');
@@ -99,6 +123,44 @@ export const validateDesignConfig = (config) => {
 	if (config.trimColor && !hexColorRegex.test(config.trimColor)) {
 		errors.push('Invalid trim color format');
 	}
+
+	// The catalog is a fixed list of combinations, not a formula, so a size
+	// outside it has no price to quote — check it before asking about it.
+	if (!Number.isFinite(config.width) || !Number.isFinite(config.length)) {
+		errors.push('Width and length must both be numbers');
+	} else if (!TIERS.includes(config.tier)) {
+		errors.push(`Tier must be one of ${TIERS.join(' or ')}`);
+	} else if (!isValidCombo(config.width, config.length, config.tier)) {
+		errors.push(
+			`The catalog does not sell ${config.width}x${config.length} as ${config.tier}`
+		);
+	}
+
+	if (config.placements !== undefined && !Array.isArray(config.placements)) {
+		errors.push('Placements must be an array');
+	} else if (Array.isArray(config.placements)) {
+		config.placements.forEach((placement, i) => {
+			const where = placement?.id ?? `index ${i}`;
+			for (const axis of ['normalizedX', 'normalizedY']) {
+				const value = placement?.[axis];
+				if (!Number.isFinite(value)) {
+					errors.push(`Placement ${where} has a non-finite ${axis}`);
+				} else if (value < 0 || value > 1) {
+					errors.push(`Placement ${where} has ${axis} outside its wall`);
+				}
+			}
+			for (const dimension of ['width', 'height']) {
+				const value = placement?.[dimension];
+				if (!Number.isFinite(value) || value <= 0) {
+					errors.push(`Placement ${where} has an invalid ${dimension}`);
+				}
+			}
+			if (!WALL_SIDES.includes(placement?.wall)) {
+				errors.push(`Placement ${where} names a wall the shed does not have`);
+			}
+		});
+	}
+
 	return {
 		isValid: errors.length === 0,
 		errors,

--- a/frontend/src/services/designApi.test.js
+++ b/frontend/src/services/designApi.test.js
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest';
+import { validateDesignConfig } from './designApi';
+
+/**
+ * The gate `useDesignPersistence.save()` runs before POSTing a Design.
+ *
+ * Sizes and Tiers below are read off `shed-options.md`, the catalog of
+ * record, not off the price table the code consults.
+ */
+
+// 12x16 Standard is a real line in the catalog at $6089.
+const validConfig = (overrides = {}) => ({
+	width: 12,
+	length: 16,
+	tier: 'Standard',
+	model: 'Gable',
+	color: '#D2691E',
+	roofColor: '#8B4513',
+	trimColor: '#654321',
+	placements: [],
+	options: {},
+	price: 6089,
+	...overrides,
+});
+
+const opening = (overrides = {}) => ({
+	id: 'p1',
+	type: 'window',
+	wall: 'front',
+	normalizedX: 0.5,
+	normalizedY: 0.5,
+	width: 3,
+	height: 3,
+	...overrides,
+});
+
+describe('validateDesignConfig', () => {
+	it('accepts a Design the store can actually hold', () => {
+		expect(validateDesignConfig(validConfig())).toEqual({ isValid: true, errors: [] });
+	});
+
+	describe('the Design as a whole', () => {
+		it('rejects a Model that is not a product line', () => {
+			const { isValid, errors } = validateDesignConfig(validConfig({ model: 'Skillion' }));
+			expect(isValid).toBe(false);
+			expect(errors.join(' ')).toMatch(/Barn|Gable/);
+		});
+
+		it('rejects a colour that is not a hex triplet', () => {
+			expect(validateDesignConfig(validConfig({ roofColor: 'chartreuse' })).isValid).toBe(false);
+		});
+
+		it('rejects a size the catalog does not sell', () => {
+			// 14-wide appears only under "Deluxe barns & gables" — there is no
+			// Standard 14x20 to sell, so a Quote for one cannot be honoured.
+			expect(validateDesignConfig(validConfig({ width: 14, length: 20 })).isValid).toBe(false);
+			// 12x26 is likewise Deluxe-only.
+			expect(validateDesignConfig(validConfig({ width: 12, length: 26 })).isValid).toBe(false);
+			// And 10x18 is not a length the catalog lists at any grade.
+			expect(validateDesignConfig(validConfig({ width: 10, length: 18 })).isValid).toBe(false);
+		});
+
+		it('accepts those same sizes at the grade that does sell them', () => {
+			expect(validateDesignConfig(
+				validConfig({ width: 14, length: 20, tier: 'Deluxe' })
+			).isValid).toBe(true);
+			expect(validateDesignConfig(
+				validConfig({ width: 12, length: 26, tier: 'Deluxe' })
+			).isValid).toBe(true);
+		});
+
+		it('rejects a dimension that is missing or not a number', () => {
+			expect(validateDesignConfig(validConfig({ width: undefined })).isValid).toBe(false);
+			expect(validateDesignConfig(validConfig({ length: '16' })).isValid).toBe(false);
+			expect(validateDesignConfig(validConfig({ tier: 'Premium' })).isValid).toBe(false);
+		});
+	});
+
+	describe('Placements', () => {
+		it('rejects a non-finite coordinate', () => {
+			// JSON.stringify(NaN) is "null", so this saves clean and comes back
+			// on load as an Opening whose cut box is at null — a wall that
+			// silently fails to cut, or throws inside the evaluator.
+			for (const bad of [NaN, Infinity, -Infinity, undefined, null, '0.5']) {
+				expect(validateDesignConfig(
+					validConfig({ placements: [opening({ normalizedX: bad })] })
+				).isValid).toBe(false);
+				expect(validateDesignConfig(
+					validConfig({ placements: [opening({ normalizedY: bad })] })
+				).isValid).toBe(false);
+			}
+		});
+
+		it('rejects a coordinate off its own wall', () => {
+			// Normalized position runs 0 to 1 across the wall.
+			expect(validateDesignConfig(
+				validConfig({ placements: [opening({ normalizedX: 1.4 })] })
+			).isValid).toBe(false);
+			expect(validateDesignConfig(
+				validConfig({ placements: [opening({ normalizedY: -0.2 })] })
+			).isValid).toBe(false);
+		});
+
+		it('rejects an Opening with no size', () => {
+			for (const bad of [0, -3, NaN, undefined]) {
+				expect(validateDesignConfig(
+					validConfig({ placements: [opening({ width: bad })] })
+				).isValid).toBe(false);
+				expect(validateDesignConfig(
+					validConfig({ placements: [opening({ height: bad })] })
+				).isValid).toBe(false);
+			}
+		});
+
+		it('rejects a Placement on a wall the shed does not have', () => {
+			expect(validateDesignConfig(
+				validConfig({ placements: [opening({ wall: 'roof' })] })
+			).isValid).toBe(false);
+		});
+
+		it('accepts an Opening at the very edges of its wall', () => {
+			expect(validateDesignConfig(
+				validConfig({ placements: [opening({ normalizedX: 0, normalizedY: 1 })] })
+			).isValid).toBe(true);
+		});
+
+		it('names the Placement that is wrong, so the message is actionable', () => {
+			const { errors } = validateDesignConfig(validConfig({
+				placements: [opening({ id: 'a' }), opening({ id: 'b', normalizedX: NaN })],
+			}));
+			expect(errors).toHaveLength(1);
+			expect(errors[0]).toMatch(/\bb\b|\b1\b/);
+		});
+	});
+
+	it('reports every problem at once rather than only the first', () => {
+		const { errors } = validateDesignConfig(validConfig({
+			model: 'Skillion',
+			color: 'not-a-colour',
+			placements: [opening({ normalizedX: NaN })],
+		}));
+		expect(errors.length).toBeGreaterThanOrEqual(3);
+	});
+});


### PR DESCRIPTION
Closes #19.

`validateDesignConfig` checked the Model and three colours. It now also checks that the size is a combination the catalog sells, and that every Placement could actually be drawn: finite coordinates inside `[0, 1]`, a positive width and height, and a wall the shed has.

The coordinates are the point. `JSON.stringify(NaN)` is `"null"`, so a Placement with a non-finite coordinate saved clean and came back on load as an Opening whose cut box is at `null` — a wall that silently fails to cut its hole, or throws inside the evaluator and logs to a console nobody is reading.

## The server-side mirror found a sharper version of the same bug

The issue asks for this to be mirrored because the server stored whatever `placements` array it was handed. Doing so turned up something worse than the client case: **Go decodes JSON `null` into a `float64` as `0` without complaint.** The server would not have thrown — it would have accepted the Opening and quietly moved it to the bottom-left corner of its wall.

So `Placement`'s coordinate fields are now `*float64`, which is what makes "absent" distinguishable from "zero". Once validated they are never nil, so the stored JSON is unchanged — and there is a test asserting the round trip echoes `0` back as `0`.

## Deliberately not checked

- **Whether an Opening fits its wall.** `utils/placementValidator.js` owns that. This asks whether the data is well-formed; that asks whether the shed is buildable. Two answers to one question is how they drift.
- **`price`.** The server recomputes it and ignores what the client sent (ADR-0008), so there is nothing here worth guarding.

## Notes

Every problem is reported rather than only the first — a customer fixing one field at a time because the gate names one at a time is worse than a list.

Sizes and Tiers in the tests are read off `shed-options.md`, not off the price table the code consults: 14x20 and 12x26 are Deluxe-only lines, so they must fail as Standard and pass as Deluxe.

## Verification

98 frontend tests (13 new), Go tests pass including 10 new subtests, `go vet` and `gofmt` clean, build clean, lint unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)