### PR TITLE
docs: correct ADR-0006 and CONTEXT.md to the trim set that ships

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -130,7 +130,8 @@ slope.
 
 **Rake**:
 The sloped edge of a roof at a gable or barn end. Straight on a Gable; on a Barn it breaks
-at the Knuckle and runs as two boards per side.
+at the Knuckle and runs as two segments per side. What sits along it differs by Model: a
+Gable carries a boxed rake board, a Barn carries the **Fly** under the metal.
 
 **Eave**:
 The horizontal lower edge of a roof, along the long walls.
@@ -148,11 +149,15 @@ product, not a difference in the renderer.
 | | Corner Boards | Fascia | Rake | Eave overhang |
 |---|---|---|---|---|
 | Gable | yes | yes | yes, overhanging ~5in with a return at the eave | yes |
-| Barn | yes | **no** | yes, following the gambrel | ~none, roof stops at the wall |
+| Barn | yes | **no** | yes, following the gambrel | 2in, finishing in J-channel |
 
-Trim stock measures about 5.5in (1x6) against a known width in the Reference Photos, not
-the 4in the renderer assumes. Every roof also carries a **Ridge Cap** the renderer does
-not draw. Read off the Reference Photos; see issue #22.
+Trim stock is 4in (1x4), measured at 15-18px on a photograph scaling at 48.5 px/ft. An
+earlier reading of these photos put it at 5.5in (1x6); the closer measurement agrees with
+the 4in the renderer had always used. The face you see and the standoff off the siding are
+two different numbers — see **Trim Stock**.
+
+The eave overhang is a per-Model shop spec, not one number: a Gable gets a 6 5/8in soffit
+and fascia box, except at 16 wide where it is 4 7/8in; a Barn gets 2in.
 
 **Corner Board**:
 A vertical trim board at a corner of the shed, covering the siding joint. Four
@@ -165,7 +170,37 @@ _Avoid_: eave board, trim board (say which board)
 
 **Ridge Cap**:
 The folded metal closure over the ridge of a Gable or the peak of a gambrel. Present on
-every Reference Photo; not modelled.
+every Reference Photo, and on both Models in the renderer. It is roofing, not trim: it is
+drawn in the roof colour by the roof, never by the Trim Set.
+
+**Trim Stock**:
+A trim board has two numbers and they are not the same number. The **face** is what you
+see, 4in. The **standoff** is how far the board stands off the siding, a dressed 1x. They
+were one value once, which put every corner board inside the wall with its faces exactly
+coplanar — nothing decided which surface won and each board rendered as hatched noise.
+A corner board is nailed *on* the siding, and the two boards at a corner lap rather than
+butt: one runs past to cover the other's end grain.
+
+**Fly**:
+The flat board along a Barn's rake, under the roof panel. Not a fascia and not a rake
+board in the Gable sense — a flat 2x4, so 1.5in on the face. The panel runs past it and
+laps it, which is why it reads as a band in the photographs rather than as an edge.
+
+**J-Channel**:
+The formed metal channel the roof panel's edge slides into, along the rake on both
+Models. It is what holds the metal in at the front and back top edges. Roofing, not
+trim: the same galvanized stock as the panel, and it reads dark in a photograph only
+because it faces away from the sky.
+
+**Knuckle Flashing**:
+The bent metal cap over a Barn's Knuckle, closing the joint where the two gambrel slopes
+meet. Two legs, one down each slope. Roofing, in the roof colour.
+_Avoid_: gambrel break flashing (say Knuckle)
+
+**Corner Box**:
+The boxed soffit return where a Gable's rake overhang meets its eave, at each of the four
+corners. Part of the Gable's Trim Set; a Barn has none, its rake finishing in J-channel
+instead.
 
 Trim colour is one colour. Where a photo appears to show two, the second is the window's
 or door's own factory frame — a white vinyl window or a white steel entry door — sitting

--- a/docs/adr/0006-style-specific-trim-components.md
+++ b/docs/adr/0006-style-specific-trim-components.md
@@ -6,10 +6,18 @@
 | Date | Description |
 |------|-------------|
 | 2026-04-19 | Document created |
+| 2026-08-30 | Corrected the per-Model trim set against the Reference Photos (#22). This ADR had the Barn exactly backwards: it prescribed corner boards plus eave fascia and told the implementer to "omit rake board geometry entirely", when a Barn in fact carries corner boards **and a rake**, and **no fascia**. The Tradeoffs section's claimed fascia duplication therefore never existed. Also replaced the flat `overhangEave` default, which was a Gable number applied to both Models. |
 
 ## Context
 
 Architectural trim (corner boards, eave fascia, rake/barge boards) is a defining visual feature of real sheds that is currently missing from the 3D renderer. Trim geometry differs materially between the two shed styles: gable sheds require rake/barge boards that follow the roof slope on each gable end, while gambrel (barn) sheds have no triangular gable face and therefore no rake boards at all.
+
+**Corrected 2026-08-30 (#22).** The second half of that sentence is false, and it is the error the rest of this document is built on. A Barn does have a gable end — a gambrel face, not a triangle — and the Reference Photos show it carrying the most visually defining trim on the building: a band following the roofline the whole way, up the steep lower slope, across the Knuckle, and up the shallow upper slope to the peak. What a Barn does *not* carry is eave fascia; its long walls run straight up into the roof edge with no board. The trim set per Model, read off the photographs:
+
+| | Corner boards | Eave fascia | Rake |
+|---|---|---|---|
+| Gable | yes | **yes** | yes, straight |
+| Barn | yes | **no** | **yes, following the gambrel** |
 
 ## Decision
 
@@ -24,18 +32,18 @@ We will implement trim as two separate style-specific components—`GableTrim` a
 - Future shed styles (lean-to, saltbox, etc.) each receive their own trim component rather than contributing another branch to a shared conditional component.
 
 **Tradeoffs:**
-- Corner board and eave fascia geometry code is duplicated between `GableTrim` and `BarnTrim`. Both files compute identical formulas for the four vertical corner boards and the horizontal eave fascia boards. This duplication is accepted because the geometry is simple and per-style isolation is the higher priority.
+- ~~Corner board and eave fascia geometry code is duplicated between `GableTrim` and `BarnTrim`. Both files compute identical formulas for the four vertical corner boards and the horizontal eave fascia boards. This duplication is accepted because the geometry is simple and per-style isolation is the higher priority.~~ **Corrected 2026-08-30 (#22):** this duplication never existed and could not have — only a Gable carries eave fascia. The corner boards, which genuinely are the same board on both Models, are not duplicated either: ADR-0011's rule was extended to trim, and `cornerBoards` in `utils/trimGeometry.js` is the single place a corner position is worked out. Neither component computes a trim position; both ask.
 - A single `ShedTrim` component with a `style` prop would consolidate the shared geometry in one place, but would require conditional rendering for rake boards and divergent prop sets, making the component nearly as large as two separate components while obscuring which geometry belongs to which style.
 
 **Operational Implications:**
 - Rake board angle in `GableTrim` is computed as `Math.atan2(roofHeight, halfWidth)`, which must stay synchronized with the same formula used in `GableRoof` to ensure trim boards seat flush against the roof surface.
-- Both components accept `trimWidth=0.333` (approximately 4 inches) and `overhangEave=0.5` as defaulted props, so callers that do not pass these values will get standard lumber dimensions without explicit configuration.
+- Both components accept `trimWidth=0.333` (approximately 4 inches), which the Reference Photos confirm — measured at 15-18px on a photo scaling at 48.5 px/ft. ~~and `overhangEave=0.5` as defaulted props~~ **Corrected 2026-08-30 (#22):** a single `0.5 ft` eave overhang was a Gable number applied to both Models. The overhang is a per-Model shop spec and comes from `roofOverhangFt(model, width)`: a Gable gets a 6 5/8in soffit and fascia box, except at 16 wide where it is 4 7/8in; a Barn gets 2in and finishes in J-channel. Trim components take the overhang as a prop rather than defaulting it.
 - Neither component reads from the Zustand store directly; they receive all configuration through props from their parent orchestration component, consistent with the section component boundary rule in ADR-004.
 
 ## Implementation
 
 1. Create `frontend/src/components/shed/trim/GableTrim.jsx` implementing corner boards, eave fascia boards, and rake/barge boards. Compute rake board angle via `Math.atan2(roofHeight, halfWidth)` and length via `Math.sqrt(halfWidth ** 2 + roofHeight ** 2)`.
-2. Create `frontend/src/components/shed/trim/BarnTrim.jsx` implementing corner boards and eave fascia boards only. Omit rake board geometry entirely.
+2. ~~Create `frontend/src/components/shed/trim/BarnTrim.jsx` implementing corner boards and eave fascia boards only. Omit rake board geometry entirely.~~ **Corrected 2026-08-30 (#22):** `BarnTrim` implements corner boards and the rake band, and omits eave fascia — the reverse of the original instruction. The rake is two runs per side, not one: it breaks at the Knuckle and follows both gambrel slopes. It is also not a board. The roof panel runs past the wall and finishes in J-channel, and what the photographs show along that edge is the fly *under* the metal, so the panel edge laps it.
 3. Define the shared prop interface for both components: `shedWidth`, `shedLength`, `wallHeight`, `trimColor`, `trimWidth` (default `0.333`), `overhangEave` (default `0.5`). Add `roofHeight` (default `4`) exclusively to `GableTrim`.
 4. Apply `meshStandardMaterial` directly in both components using `trimColor` as the `color` prop. Do not route trim boards through the shader factory from ADR-002, as trim is simple painted wood requiring no procedural surface pattern.
 5. Import `GableTrim` in `GableShed.jsx` and `BarnTrim` in `BarnShed.jsx`, passing props from the orchestration component's store-derived values. Ensure neither trim component is imported by the other orchestration component.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -13,3 +13,43 @@ The skills speak in terms of five canonical triage roles. This file maps those r
 When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
 
 Edit the right-hand column to match whatever vocabulary you actually use.
+
+## The two labels every issue carries
+
+An issue carries exactly **one category** (`bug`, `enhancement`, `documentation`) and
+exactly **one state** from the table above. The category says what kind of thing it is;
+the state says where it is in the pipeline. An issue with only a category has not been
+triaged — it is invisible to both queries below.
+
+## The queues
+
+The point of the state label is that picking work becomes a query instead of a reread:
+
+```bash
+gh issue list --state open --label ready-for-agent   # hand to an agent
+gh issue list --state open --label ready-for-human   # your own list
+```
+
+The line between them is not difficulty. It is whether a machine can finish the job:
+
+- **`ready-for-agent`** — the spec is complete and the acceptance criteria are checkable
+  without a person. Mechanical work with a known answer.
+- **`ready-for-human`** — finishing it needs judgment, a design call, external access, or
+  a sign-off. The fidelity issues live here permanently: their acceptance criterion is a
+  human looking at a render beside a photograph, which no agent can supply.
+
+## Blocked is not a state
+
+There are five states and none of them is "blocked", because blocking is a *relationship*
+between two issues rather than a property of one. Use GitHub's native issue dependencies
+(see `issue-tracker.md`), which the UI renders and `gh` can query:
+
+```bash
+gh api repos/<owner>/<repo>/issues/<n>/dependencies/blocked_by --jq '[.[]|"#\(.number)"]'
+```
+
+So a fully-specified issue queued behind another still gets `ready-for-agent`, plus an
+edge naming its blocker. Downgrading it to `needs-triage` instead would be a lie — the
+spec is fine, the timing isn't — and the state would have to be remembered and reverted
+when the blocker closes. The edge does that on its own: an issue is pickable when it is
+`ready-for-agent` and its `blocked_by` list has no open issues left in it.


### PR DESCRIPTION
> *This was generated by AI during triage.*

Closes #22 — the documentation half. The code half shipped in #38.

## What was wrong

**ADR-0006** had the Barn exactly backwards. Implementation step 2 told the implementer to build `BarnTrim` with "corner boards and eave fascia boards only" and to "omit rake board geometry entirely". The photographs say the reverse: a Barn carries corner boards **and a rake**, and **no fascia**.

The error starts in the Context section, which asserts a gambrel has no gable face and therefore no rake at all, and propagates into a Tradeoffs bullet trading off a corner-board-and-fascia duplication that could never have existed — only a Gable has fascia. Corrections are marked inline and dated in the revision log rather than rewritten, so the original reasoning stays readable next to what replaced it.

Also replaces the flat `overhangEave=0.5` default, which was a Gable number applied to both Models. The overhang is a per-Model shop spec and comes from `roofOverhangFt(model, width)`.

**CONTEXT.md** had drifted the *other* way — it was correct when written and the code moved past it:

| Said | Ships |
|---|---|
| trim stock ~5.5in (1x6), "not the 4in the renderer assumes" | 4in, re-measured at 15–18px on a photo scaling at 48.5 px/ft |
| "a **Ridge Cap** the renderer does not draw" / "not modelled" | capped on both Models, in the roof colour |
| Barn eave overhang "~none, roof stops at the wall" | 2in, finishing in J-channel |

## New vocabulary

Four terms the fidelity work settled verbally and never wrote down — **Fly**, **J-Channel**, **Knuckle Flashing**, **Corner Box** — plus **Trim Stock**, which records that a trim board has two numbers (the 4in face and the dressed-1x standoff) and that collapsing them into one is what caused the corner boards to z-fight.

The Fly and the J-Channel entries carry the distinction the photos settle: both are **roofing, not trim**. The panel laps the fly, and the J-channel is the same galvanized stock as the panel — it reads dark only because it faces away from the sky.

## Verification

Docs only; no code touched. Frontend suite unaffected: 178 passed, 1 expected fail, 1 todo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpBS1UKbHqnu3ox13Rohte