### PR TITLE
Mitre every band along a roof edge, and cut the trim to fit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,36 @@ panel runs 2in past and finishes in J-channel, and what the photographs show is 
 it. That is the half of issue #22 the photos settle — ADR-0006 says the Barn has fascia, the
 component said it has none, and both were half right.
 
+**A band that follows a roof edge is one mitred outline, never a run of boxes.** `mitredBand`
+builds it: both edges are offset copies of the slab's top line, consecutive runs are intersected
+rather than butted, and the two ends are cut plumb — the way `slabFrom` cuts the slab. A box is
+cut square across its own axis, so however carefully the centre lines were mitred the corners
+still overshot: the Gable's two rake boards left a wedge of daylight above the apex and crossed
+below it, and every Knuckle had the same defect in proportion to its angle. The outlines reach a
+mesh through `ExtrudedBand`. The rake, the Barn's fly and the J-channel over either are all
+bands; the ridge cap and the Knuckle flashing run along the shed instead and stay boxes.
+
+A plumb cut is the right end on a 6:12 and the wrong one on a Barn: the steeper the run, the
+longer the point it leaves below the band, and the fly hung 2.5in of paint below the roof it is
+tucked under. `mitredBand`'s `endFloor` cuts that end level, and `barnRakeFlashing` sets it to
+the slab's own underside — the fly stops where the metal stops, which is what the photographs
+show, with the corner board taking over below. Nothing else passes it.
+
+Rake and eave are one board turning a corner, so the numbers that place their faces are shared,
+not chosen twice. Both hang `eaveFasciaDrop` below the roof's edge — the rake's own perpendicular
+`RAKE_REVEAL`, converted to plumb — and both are `ROOF_THICKNESS` deep measured plumb, which is
+how much slab edge there is to cover. A flat eave reveal of its own put the eave fascia an inch
+and a half above the rake it meets. The eave then runs a board's thickness past the slab at each
+end to lap the rake's plumb cut, the way the two boards at a corner lap.
+
+A corner board is an outline too, for the same reason: its top is not always level. A Barn cuts
+it on the **roof's underside** — parallel to the fly, so it carries the gambrel's angle, and as
+high as a board can go before it enters the slab. Level at the eave, the tops were buried in the
+roof; on the fly's own lower edge, which hangs 2.4in under the slab, that much siding showed
+between the board and the fly from anywhere but dead on. `bandUnderside` gives the line, and a
+band of no width is the surface itself. A Gable leaves the default, level at the eave. The bottom
+is never cut: it is flat and on the floor, `y = 0`.
+
 Trim stock has two numbers, and they are not the same number: `TRIM_WIDTH` is the face you see
 (`0.333 ft`, 4in — now measured, at 15–18px on a photo that scales at 48.5 px/ft) and
 `TRIM_THICKNESS` is how far the board stands off the siding (`0.0625 ft`, a dressed 1x). They

--- a/docs/adr/0006-style-specific-trim-components.md
+++ b/docs/adr/0006-style-specific-trim-components.md
@@ -7,6 +7,7 @@
 |------|-------------|
 | 2026-04-19 | Document created |
 | 2026-08-30 | Corrected the per-Model trim set against the Reference Photos (#22). This ADR had the Barn exactly backwards: it prescribed corner boards plus eave fascia and told the implementer to "omit rake board geometry entirely", when a Barn in fact carries corner boards **and a rake**, and **no fascia**. The Tradeoffs section's claimed fascia duplication therefore never existed. Also replaced the flat `overhangEave` default, which was a Gable number applied to both Models. |
+| 2026-08-31 | Corrected implementation step 1 (the Gable's rake). It prescribed an angle and a length for two rake boards; the rake is one mitred outline per end, and the two boards it described could not close at the apex or reach the eave fascia however they were sized. |
 
 ## Context
 
@@ -42,7 +43,7 @@ We will implement trim as two separate style-specific components—`GableTrim` a
 
 ## Implementation
 
-1. Create `frontend/src/components/shed/trim/GableTrim.jsx` implementing corner boards, eave fascia boards, and rake/barge boards. Compute rake board angle via `Math.atan2(roofHeight, halfWidth)` and length via `Math.sqrt(halfWidth ** 2 + roofHeight ** 2)`.
+1. ~~Create `frontend/src/components/shed/trim/GableTrim.jsx` implementing corner boards, eave fascia boards, and rake/barge boards. Compute rake board angle via `Math.atan2(roofHeight, halfWidth)` and length via `Math.sqrt(halfWidth ** 2 + roofHeight ** 2)`.~~ **Corrected 2026-08-31:** `GableTrim` computes nothing — ADR-0011's rule was extended to trim and every fascia position comes from `gableFasciaBoards`. The rake has no single angle or length to compute either: it is one mitred outline per gable end, offset from the roof slab's top line rather than from the wall, and cut plumb at the apex and at both eaves. Two boards with the right angle and the right length still do not meet, because a box is cut square across its own axis.
 2. ~~Create `frontend/src/components/shed/trim/BarnTrim.jsx` implementing corner boards and eave fascia boards only. Omit rake board geometry entirely.~~ **Corrected 2026-08-30 (#22):** `BarnTrim` implements corner boards and the rake band, and omits eave fascia — the reverse of the original instruction. The rake is two runs per side, not one: it breaks at the Knuckle and follows both gambrel slopes. It is also not a board. The roof panel runs past the wall and finishes in J-channel, and what the photographs show along that edge is the fly *under* the metal, so the panel edge laps it.
 3. Define the shared prop interface for both components: `shedWidth`, `shedLength`, `wallHeight`, `trimColor`, `trimWidth` (default `0.333`), `overhangEave` (default `0.5`). Add `roofHeight` (default `4`) exclusively to `GableTrim`.
 4. Apply `meshStandardMaterial` directly in both components using `trimColor` as the `color` prop. Do not route trim boards through the shader factory from ADR-002, as trim is simple painted wood requiring no procedural surface pattern.

--- a/frontend/src/components/common/ExtrudedBand.jsx
+++ b/frontend/src/components/common/ExtrudedBand.jsx
@@ -1,0 +1,35 @@
+import { useMemo } from 'react';
+import * as THREE from 'three';
+
+/**
+ * One band along a roof edge, extruded from the outline `trimGeometry` hands
+ * back — a rake fascia, a Barn's fly, or the J-channel over either.
+ *
+ * A band is a mitred polygon in the gable-end plane, which is the whole point
+ * of `mitredBand`: a box is cut square across its own axis and cannot close a
+ * corner. So it is built the way the roof slab itself is, shape then extrude,
+ * with the outline's `y` measured from the top of the wall and the extrusion
+ * running back along Z.
+ *
+ * `<extrudeGeometry>` is a React Three Fiber element rather than a
+ * `<primitive>`, so the geometry is disposed for us. Memoise the outline in
+ * the caller all the same — a fresh array every render rebuilds the shape.
+ */
+export const ExtrudedBand = ({ outline, position, depth, children }) => {
+  const shape = useMemo(() => {
+    const s = new THREE.Shape();
+    s.moveTo(outline[0][0], outline[0][1]);
+    for (const [x, y] of outline.slice(1)) s.lineTo(x, y);
+    s.closePath();
+    return s;
+  }, [outline]);
+
+  const settings = useMemo(() => ({ depth, bevelEnabled: false }), [depth]);
+
+  return (
+    <mesh position={position} castShadow receiveShadow>
+      <extrudeGeometry args={[shape, settings]} />
+      {children}
+    </mesh>
+  );
+};

--- a/frontend/src/components/shed/roofs/GableRoof.jsx
+++ b/frontend/src/components/shed/roofs/GableRoof.jsx
@@ -3,6 +3,7 @@ import * as THREE from 'three';
 import { makeRoofShader } from '../../../utils/shaders';
 import { gableRoofProfile, gableRoofTopLine, roofSlabDepth, ROOF_THICKNESS } from '../../../utils/roofGeometry';
 import { roofRidgeCap, rakeJChannel } from '../../../utils/trimGeometry';
+import { ExtrudedBand } from '../../common/ExtrudedBand';
 import { Skylight } from '../extras/Skylight';
 
 /**
@@ -62,18 +63,28 @@ export const GableRoof = ({
 
   const peakY = wallHeight + roofHeight;
 
-  // The roof's own metalwork: the ridge cap folded over the peak, and the
-  // J-channel capping both gable-end top edges. Roof metal, so it renders
-  // here in the roof colour rather than with the trim.
-  const metalwork = useMemo(() => {
+  const METAL_MAT = {
+    color: roofColor,
+    roughness: roofMaterial === 'metal' ? 0.35 : 0.7,
+    metalness: roofMaterial === 'metal' ? 0.4 : 0.05,
+  };
+
+  // The roof's own metalwork, in the roof colour rather than with the trim.
+  // The ridge cap runs the length of the shed and is a box; the J-channel
+  // follows the gable-end edge, so it is a mitred outline like the fascia
+  // under it and is extruded rather than boxed.
+  const ridgeCap = useMemo(() => {
     const slope = roofHeight / (shedWidth / 2);
-    return [
-      ...roofRidgeCap(roofHeight, slope, shedLength, wallHeight, { overhang }),
-      ...rakeJChannel(gableRoofTopLine(shedWidth, pitchX, { overhang }), shedLength, wallHeight, {
+    return roofRidgeCap(roofHeight, slope, shedLength, wallHeight, { overhang });
+  }, [shedWidth, shedLength, wallHeight, roofHeight, overhang]);
+
+  const jChannel = useMemo(
+    () =>
+      rakeJChannel(gableRoofTopLine(shedWidth, pitchX, { overhang }), shedLength, wallHeight, {
         overhang,
       }),
-    ];
-  }, [shedWidth, shedLength, wallHeight, roofHeight, pitchX, overhang]);
+    [shedWidth, shedLength, wallHeight, pitchX, overhang]
+  );
 
   return (
     <group name="gableRoof">
@@ -87,15 +98,18 @@ export const GableRoof = ({
         <shaderMaterial args={[roofShader]} side={THREE.DoubleSide} />
       </mesh>
 
-      {metalwork.map(({ id, position, size, rotation }) => (
+      {ridgeCap.map(({ id, position, size, rotation }) => (
         <mesh key={id} position={position} rotation={rotation} castShadow>
           <boxGeometry args={size} />
-          <meshStandardMaterial
-            color={roofColor}
-            roughness={roofMaterial === 'metal' ? 0.35 : 0.7}
-            metalness={roofMaterial === 'metal' ? 0.4 : 0.05}
-          />
+          <meshStandardMaterial {...METAL_MAT} />
         </mesh>
+      ))}
+
+      {/* `depth` renamed: the slab's own `depth` is already in scope here */}
+      {jChannel.map(({ id, outline, position, depth: bandDepth }) => (
+        <ExtrudedBand key={id} outline={outline} position={position} depth={bandDepth}>
+          <meshStandardMaterial {...METAL_MAT} />
+        </ExtrudedBand>
       ))}
 
       {skylight?.enabled && (

--- a/frontend/src/components/shed/roofs/GambrelRoof.jsx
+++ b/frontend/src/components/shed/roofs/GambrelRoof.jsx
@@ -11,6 +11,7 @@ import {
 import { Skylight } from '../extras/Skylight';
 import { barnKnuckleFlashing, roofRidgeCap, rakeJChannel } from '../../../utils/trimGeometry';
 import { gambrelEndOutline, gambrelRoofTopLine } from '../../../utils/roofGeometry';
+import { ExtrudedBand } from '../../common/ExtrudedBand';
 
 /**
  * GambrelRoof — the barn roof, as a slab.
@@ -65,10 +66,10 @@ export const GambrelRoof = ({
     [roofColor, roofMaterial]
   );
 
-  // The roof's own metalwork: break flashing over each Knuckle, the ridge
-  // cap, and the J-channel capping both gable-end top edges. All of it is
-  // roof metal, so it renders here in the roof colour rather than with the
-  // trim.
+  // The roof's own metalwork, in the roof colour rather than with the trim.
+  // Break flashing over each Knuckle and the ridge cap both run the length of
+  // the shed and are boxes; the J-channel follows the gable-end edge, so it is
+  // a mitred outline like the fly under it and is extruded rather than boxed.
   const metalwork = useMemo(() => {
     const topLine = gambrelRoofTopLine(shedWidth, roofLowerPitch, roofUpperPitch, { overhang });
     const peak = topLine.reduce((hi, p) => Math.max(hi, p[1]), -Infinity);
@@ -80,9 +81,19 @@ export const GambrelRoof = ({
         { overhang }
       ),
       ...roofRidgeCap(peak, roofUpperPitch / 12, shedLength, wallHeight, { overhang }),
-      ...rakeJChannel(topLine, shedLength, wallHeight, { overhang }),
     ];
   }, [shedWidth, shedLength, wallHeight, roofLowerPitch, roofUpperPitch, overhang]);
+
+  const jChannel = useMemo(
+    () =>
+      rakeJChannel(
+        gambrelRoofTopLine(shedWidth, roofLowerPitch, roofUpperPitch, { overhang }),
+        shedLength,
+        wallHeight,
+        { overhang }
+      ),
+    [shedWidth, shedLength, wallHeight, roofLowerPitch, roofUpperPitch, overhang]
+  );
 
   // Highest point of the profile, for anything that sits on the ridge.
   const peakY = useMemo(() => {
@@ -92,6 +103,12 @@ export const GambrelRoof = ({
     });
     return points.reduce((hi, p) => Math.max(hi, p[1]), -Infinity);
   }, [shedWidth, roofLowerPitch, roofUpperPitch, overhang]);
+
+  const METAL_MAT = {
+    color: roofColor,
+    roughness: roofMaterial === 'metal' ? 0.35 : 0.7,
+    metalness: roofMaterial === 'metal' ? 0.4 : 0.05,
+  };
 
   return (
     <group name="gambrelRoof">
@@ -108,12 +125,15 @@ export const GambrelRoof = ({
       {metalwork.map(({ id, position, size, rotation }) => (
         <mesh key={id} position={position} rotation={rotation} castShadow>
           <boxGeometry args={size} />
-          <meshStandardMaterial
-            color={roofColor}
-            roughness={roofMaterial === 'metal' ? 0.35 : 0.7}
-            metalness={roofMaterial === 'metal' ? 0.4 : 0.05}
-          />
+          <meshStandardMaterial {...METAL_MAT} />
         </mesh>
+      ))}
+
+      {/* `depth` renamed: the slab's own `depth` is already in scope here */}
+      {jChannel.map(({ id, outline, position, depth: bandDepth }) => (
+        <ExtrudedBand key={id} outline={outline} position={position} depth={bandDepth}>
+          <meshStandardMaterial {...METAL_MAT} />
+        </ExtrudedBand>
       ))}
 
       {skylight?.enabled && (

--- a/frontend/src/components/shed/trim/BarnTrim.jsx
+++ b/frontend/src/components/shed/trim/BarnTrim.jsx
@@ -1,5 +1,7 @@
-import { cornerBoards, barnRakeFlashing } from '../../../utils/trimGeometry';
-import { gambrelRoofTopLine } from '../../../utils/roofGeometry';
+import { useMemo } from 'react';
+import { cornerBoards, barnRakeFlashing, bandUnderside } from '../../../utils/trimGeometry';
+import { gambrelRoofTopLine, ROOF_THICKNESS } from '../../../utils/roofGeometry';
+import { ExtrudedBand } from '../../common/ExtrudedBand';
 
 /**
  * BarnTrim — what finishes a Barn's edges.
@@ -15,12 +17,16 @@ import { gambrelRoofTopLine } from '../../../utils/roofGeometry';
  * what `barnRakeFlashing` draws, which is why it is a band and not a board,
  * and why it hugs the slab's end cap with its top edge a reveal below the top
  * surface — the metal reads as a line above the white, never the other way
- * round. The channel's own metal face is `rakeJChannel`, drawn by GambrelRoof
- * in the roof colour. Issue #22.
+ * round. It arrives as one mitred outline per end rather than a run of boxes,
+ * so it turns both Knuckles and the ridge without poking past the roof's
+ * silhouette. The channel's own metal face is `rakeJChannel`, drawn by
+ * GambrelRoof in the roof colour. Issue #22.
  *
  * Corner positions come from `cornerBoards`, not from this file: they used to
  * be worked out here and in GableTrim separately, and both copies buried the
- * board inside the siding (issue #31).
+ * board inside the siding (issue #31). What this file supplies is where their
+ * tops land, because that is the one thing about a corner board a Barn does
+ * differently — it is cut to the gambrel, not to the eave.
  */
 export const BarnTrim = ({
   shedWidth,
@@ -33,28 +39,50 @@ export const BarnTrim = ({
   overhangEave = 2 / 12,
 }) => {
   const TRIM_MAT = { color: trimColor, roughness: 0.6, metalness: 0 };
-  const corners = cornerBoards(shedWidth, shedLength, wallHeight, { trimWidth });
-  const flashing = barnRakeFlashing(
-    gambrelRoofTopLine(shedWidth, roofLowerPitch, roofUpperPitch, { overhang: overhangEave }),
-    shedLength,
-    wallHeight,
-    { overhang: overhangEave }
-  );
+
+  // Memoised because every outline below becomes extruded geometry: a fresh
+  // array each render would rebuild every shape each render.
+  const { corners, flashing } = useMemo(() => {
+    const topLine = gambrelRoofTopLine(shedWidth, roofLowerPitch, roofUpperPitch, {
+      overhang: overhangEave,
+    });
+    // The corner boards are cut on the roof's underside: parallel to the fly,
+    // so they carry the gambrel's angle, and as high as a board can go before
+    // it enters the slab. Level, they buried their tops in the roof; cut on
+    // the fly's own lower edge, which hangs 2.4 in under the slab, that much
+    // siding showed between the board and the fly from anywhere but dead on.
+    // A zero-width band is the surface itself, and `slabFrom` drops the
+    // underside straight down from it.
+    const surface = bandUnderside(topLine, { reveal: 0, faceWidth: 0 });
+    return {
+      corners: cornerBoards(shedWidth, shedLength, wallHeight, {
+        trimWidth,
+        topAt: (x) => wallHeight + surface(x) - ROOF_THICKNESS,
+      }),
+      flashing: barnRakeFlashing(topLine, shedLength, wallHeight, {
+        overhang: overhangEave,
+        roofThickness: ROOF_THICKNESS,
+      }),
+    };
+  }, [shedWidth, shedLength, wallHeight, roofLowerPitch, roofUpperPitch, overhangEave, trimWidth]);
 
   return (
     <group name="barnTrim">
-      {corners.map(({ corner, face, position, size }) => (
-        <mesh key={`corner-${corner}-${face}`} position={position} castShadow receiveShadow>
-          <boxGeometry args={size} />
+      {corners.map(({ corner, face, outline, position, depth }) => (
+        <ExtrudedBand
+          key={`corner-${corner}-${face}`}
+          outline={outline}
+          position={position}
+          depth={depth}
+        >
           <meshStandardMaterial {...TRIM_MAT} />
-        </mesh>
+        </ExtrudedBand>
       ))}
 
-      {flashing.map(({ id, position, size, rotation }) => (
-        <mesh key={id} position={position} rotation={rotation} castShadow receiveShadow>
-          <boxGeometry args={size} />
+      {flashing.map(({ id, outline, position, depth }) => (
+        <ExtrudedBand key={id} outline={outline} position={position} depth={depth}>
           <meshStandardMaterial {...TRIM_MAT} />
-        </mesh>
+        </ExtrudedBand>
       ))}
     </group>
   );

--- a/frontend/src/components/shed/trim/GableTrim.jsx
+++ b/frontend/src/components/shed/trim/GableTrim.jsx
@@ -1,15 +1,20 @@
+import { useMemo } from 'react';
 import { cornerBoards, gableFasciaBoards, gableCornerBoxes, TRIM_WIDTH } from '../../../utils/trimGeometry';
 import { ROOF_THICKNESS } from '../../../utils/roofGeometry';
+import { ExtrudedBand } from '../../common/ExtrudedBand';
 
 /**
  * GableTrim — the trim set that comes with the Gable Model.
- * Renders: 4 corner boards + 2 eave fascia + 4 rake boards + 4 corner boxes.
+ * Renders: 4 corner boards + 2 rake bands + 2 eave fascia + 4 corner boxes.
  * Only imported by GableShed — never shared with BarnShed.
  *
  * Nothing here works out a position. Corner boards come from `cornerBoards`,
  * shared with BarnTrim because a corner board is the same board on both Models;
  * the fascia comes from `gableFasciaBoards`, which is the Gable's alone. Both
  * live in `utils/trimGeometry.js` (ADR-0011).
+ *
+ * The rake is a mitred outline rather than a box, so it goes through
+ * `ExtrudedBand`. The eave and the corner boxes are boxes and stay boxes.
  */
 export const GableTrim = ({
   shedWidth,
@@ -22,28 +27,55 @@ export const GableTrim = ({
 }) => {
   const TRIM_MAT = { color: trimColor, roughness: 0.6, metalness: 0 };
 
-  const corners = cornerBoards(shedWidth, shedLength, wallHeight, { trimWidth });
-  const fascia = gableFasciaBoards(shedWidth, shedLength, wallHeight, roofHeight, {
-    overhang: overhangEave,
-    roofThickness: ROOF_THICKNESS,
-  });
-  const cornerBoxes = gableCornerBoxes(shedWidth, shedLength, wallHeight, roofHeight, {
-    overhang: overhangEave,
-    roofThickness: ROOF_THICKNESS,
-  });
+  const corners = useMemo(
+    () => cornerBoards(shedWidth, shedLength, wallHeight, { trimWidth }),
+    [shedWidth, shedLength, wallHeight, trimWidth]
+  );
+
+  // Memoised because the rake outlines below become extruded geometry: a fresh
+  // array every render would rebuild both shapes every render.
+  const { rakes, eaves } = useMemo(
+    () =>
+      gableFasciaBoards(shedWidth, shedLength, wallHeight, roofHeight, {
+        overhang: overhangEave,
+        roofThickness: ROOF_THICKNESS,
+      }),
+    [shedWidth, shedLength, wallHeight, roofHeight, overhangEave]
+  );
+
+  const cornerBoxes = useMemo(
+    () =>
+      gableCornerBoxes(shedWidth, shedLength, wallHeight, roofHeight, {
+        overhang: overhangEave,
+        roofThickness: ROOF_THICKNESS,
+      }),
+    [shedWidth, shedLength, wallHeight, roofHeight, overhangEave]
+  );
 
   return (
     <group name="gableTrim">
-      {/* Corner boards */}
-      {corners.map(({ corner, face, position, size }) => (
-        <mesh key={`corner-${corner}-${face}`} position={position} castShadow receiveShadow>
-          <boxGeometry args={size} />
+      {/* Corner boards, floor to eave: a Gable's roof does not cut them */}
+      {corners.map(({ corner, face, outline, position, depth }) => (
+        <ExtrudedBand
+          key={`corner-${corner}-${face}`}
+          outline={outline}
+          position={position}
+          depth={depth}
+        >
           <meshStandardMaterial {...TRIM_MAT} />
-        </mesh>
+        </ExtrudedBand>
       ))}
 
-      {/* Rake and eave fascia, boxing in the roof slab's cut edge */}
-      {[...fascia, ...cornerBoxes].map(({ id, position, size, rotation }) => (
+      {/* The rake: one board per gable end, mitred at the apex and cut plumb
+          where the eave fascia laps it */}
+      {rakes.map(({ id, outline, position, depth }) => (
+        <ExtrudedBand key={id} outline={outline} position={position} depth={depth}>
+          <meshStandardMaterial {...TRIM_MAT} />
+        </ExtrudedBand>
+      ))}
+
+      {/* Eave fascia and the boxed soffit return at each corner */}
+      {[...eaves, ...cornerBoxes].map(({ id, position, size, rotation }) => (
         <mesh key={id} position={position} rotation={rotation} castShadow receiveShadow>
           <boxGeometry args={size} />
           <meshStandardMaterial {...TRIM_MAT} />

--- a/frontend/src/utils/trimGeometry.js
+++ b/frontend/src/utils/trimGeometry.js
@@ -56,37 +56,105 @@ export const FLY_FACE = 0.125;
 
 /**
  * How far the eave fascia and the corner boxes hang below the slab's tip
- * corner. Flush with it their top edges were coplanar with the roof's own
- * edge and sparkled through it; the photographs show the metal overhanging
- * the fascia with a drip lip there anyway.
+ * corner, in feet.
+ *
+ * The same distance the rake band hangs below its own slope, measured plumb.
+ * `RAKE_REVEAL` is perpendicular to the run, and a perpendicular drop is
+ * `hypot(1, slope)` times as far straight down — so on a 6:12 the rake's top
+ * edge is 2 in below the roof's edge and an eave fascia that picked its own
+ * reveal (it was a flat 0.04) sat an inch and a half above the rake it is
+ * supposed to join. They are one board wrapped around the corner; the number
+ * cannot be chosen twice. What shows in the gap is the slab's own edge, which
+ * is the metal drip the photographs show above the paint on both runs.
+ *
+ * @param {number} slope rise over run of the slope that reaches this eave
  */
-export const EAVE_REVEAL = 0.04;
+export function eaveFasciaDrop(slope) {
+	return RAKE_REVEAL * Math.hypot(1, slope);
+}
 
 /**
- * Offset a rake line's runs and mitre the joints.
+ * The runs of a surface line, each offset `d` perpendicular into the roof.
  *
- * Each band along a roof edge is a straight box, and a straight box cut
- * square pokes out of the roof's silhouette wherever two runs meet at an
- * angle — at the ridge the two rake boards crossed in an X, and at each
- * Knuckle the bands jutted past the edge line. Offsetting every run's centre
- * line by the same perpendicular distance and intersecting neighbours gives
- * each box the mitre point to end on instead.
- *
- * @param topLine surface polyline, walked left to right
- * @param offset perpendicular distance from the surface down to the centre
- * @returns per run: { mid, len, rot } in the profile plane
+ * The line is walked left to right, so u.x is always positive and the offset
+ * always heads downward, into the roof rather than off it.
  */
-function mitredRuns(topLine, offset) {
-	const lines = [];
-	for (let i = 0; i < topLine.length - 1; i++) {
-		const [x1, y1] = topLine[i];
+function runsBelow(topLine, d) {
+	return topLine.slice(0, -1).map(([x1, y1], i) => {
 		const [x2, y2] = topLine[i + 1];
 		const len = Math.hypot(x2 - x1, y2 - y1);
 		const u = [(x2 - x1) / len, (y2 - y1) / len];
-		// Perpendicular below the run: the line is walked left to right.
-		lines.push({ p: [x1 + (u[1] * offset), y1 - u[0] * offset], u, len });
-	}
+		return { p: [x1 + u[1] * d, y1 - u[0] * d], u };
+	});
+}
 
+/**
+ * Where a run's line crosses a plumb cut. u.x > 0 on every run, so there is
+ * always an answer, and the cut is free to fall outside the run it is taken on.
+ */
+const runAtX = (run, x) => [x, run.p[1] + run.u[1] * ((x - run.p[0]) / run.u[0])];
+
+/**
+ * The line a band's lower edge follows, as a function of x.
+ *
+ * What a corner board has to stop at. The boards at a Barn's gambrel ends run
+ * up into the fly, and cut off level they either buried their tops in the roof
+ * slab or stood proud of it — a 20:12 slope drops eight inches across the four
+ * inches of a corner board, so there is no level that works. Taking the top
+ * from the fly's own lower edge gives the board the same angle and lands the
+ * two flush.
+ *
+ * Beyond the ends of the surface line the outermost run carries on, so a board
+ * standing a little proud of the roof still gets an answer.
+ *
+ * @param {number[][]} topLine surface polyline, walked left to right
+ * @returns {(x: number) => number} the edge's height, in the line's own frame
+ */
+export function bandUnderside(topLine, { reveal, faceWidth }) {
+	const runs = runsBelow(topLine, reveal + faceWidth);
+	return (x) => {
+		let i = 0;
+		while (i < runs.length - 1 && x > topLine[i + 1][0]) i++;
+		return runAtX(runs[i], x)[1];
+	};
+}
+
+/**
+ * A band that follows a roof edge, as one closed outline.
+ *
+ * Every band along a roof — a rake fascia, the fly under a Barn's metal, the
+ * J-channel over either — is one continuous piece that changes direction at
+ * the ridge and at each Knuckle. Drawn as a run of boxes it is not one piece:
+ * a box is cut square across its own axis, so however carefully the centre
+ * lines are mitred the *corners* still overshoot. At the gable apex that left
+ * a wedge of daylight above the joint and crossing material below it, and
+ * every other break had the same defect in proportion to its angle.
+ *
+ * An outline has no joints to get wrong. Both edges of the band are offset
+ * copies of the surface line and consecutive runs are intersected rather than
+ * butted, so each break is mitred by construction. The two ends are cut
+ * **plumb**, which is how the slab itself is cut (`slabFrom` drops the top
+ * line straight down) and what lets a rake land on an eave fascia.
+ *
+ * @param {number[][]} topLine surface polyline, walked left to right
+ * @param {number} reveal perpendicular distance from the surface down to the
+ *   band's top edge; negative laps the band over the surface
+ * @param {number} faceWidth the band's face, perpendicular to the run
+ * @param {number} endX where the plumb end cuts land, defaulting to the
+ *   surface line's own ends. Both roofs are symmetric about the ridge.
+ * @param {number} endFloor a level cut across both ends: the band never hangs
+ *   below it. A plumb cut alone leaves a point below the band, and the steeper
+ *   the run the longer that point — a Barn's 20:12 lower slope hung two and a
+ *   half inches of white below the roof it is tucked under. Defaults to no cut.
+ * @returns {number[][]} closed outline in the profile plane — the top edge
+ *   left to right, the right end, the bottom edge back, then the left end
+ */
+export function mitredBand(topLine, {
+	reveal,
+	faceWidth,
+	endX = topLine[topLine.length - 1][0],
+	endFloor = -Infinity,
+}) {
 	const meet = (a, b) => {
 		const det = a.u[0] * b.u[1] - a.u[1] * b.u[0];
 		if (Math.abs(det) < 1e-9) return b.p;
@@ -94,18 +162,37 @@ function mitredRuns(topLine, offset) {
 		return [a.p[0] + a.u[0] * t, a.p[1] + a.u[1] * t];
 	};
 
-	return lines.map((line, i) => {
-		const from = i === 0 ? line.p : meet(lines[i - 1], line);
-		const to =
-			i === lines.length - 1
-				? [line.p[0] + line.u[0] * line.len, line.p[1] + line.u[1] * line.len]
-				: meet(line, lines[i + 1]);
-		return {
-			mid: [(from[0] + to[0]) / 2, (from[1] + to[1]) / 2],
-			len: Math.hypot(to[0] - from[0], to[1] - from[1]),
-			rot: Math.atan2(line.u[1], line.u[0]),
-		};
-	});
+	const atX = runAtX;
+	const atY = (run, y) => [run.p[0] + run.u[0] * ((y - run.p[1]) / run.u[1]), y];
+
+	// One end of the band: down the plumb cut, and then flat along `endFloor`
+	// if the plumb cut would have carried the band below it. `corner` is where
+	// the two cuts meet, and is null when there is nothing to take off.
+	const end = (topRun, botRun, x) => {
+		const top = atX(topRun, x);
+		const bottom = atX(botRun, x);
+		if (!(bottom[1] < endFloor && endFloor < top[1])) return { top, bottom, corner: null };
+		return { top, bottom: atY(botRun, endFloor), corner: [x, endFloor] };
+	};
+
+	const topRuns = runsBelow(topLine, reveal);
+	const botRuns = runsBelow(topLine, reveal + faceWidth);
+	const last = topRuns.length - 1;
+	const mitres = (runs) => runs.slice(1).map((run, i) => meet(runs[i], run));
+
+	const left = end(topRuns[0], botRuns[0], -endX);
+	const right = end(topRuns[last], botRuns[last], endX);
+
+	return [
+		left.top,
+		...mitres(topRuns),
+		right.top,
+		...(right.corner ? [right.corner] : []),
+		right.bottom,
+		...mitres(botRuns).reverse(),
+		left.bottom,
+		...(left.corner ? [left.corner] : []),
+	];
 }
 
 /**
@@ -121,20 +208,48 @@ function mitredRuns(topLine, offset) {
  * runs past the corner to cover the end grain of the side board, which is how
  * the joint is actually built and leaves no notch at the corner.
  *
+ * A board is an outline rather than a box because its top is not always level.
+ * A Gable's runs floor to eave; a Barn's has to be cut to the gambrel, which
+ * drops eight inches across the four inches of a corner board — see `topAt`.
+ * The bottom is always flat and always on the floor.
+ *
  * @param {number} shedWidth - feet, across the front
  * @param {number} shedLength - feet, front to back
  * @param {number} wallHeight - feet, floor to eave
- * @param {{trimWidth?: number, trimThickness?: number}} [stock]
- * @returns {Array<{corner: string, face: string, position: number[], size: number[]}>}
+ * @param {object} [stock]
+ * @param {number} [stock.trimWidth] the face you see
+ * @param {number} [stock.trimThickness] how far it stands off the siding
+ * @param {(x: number) => number} [stock.topAt] the board's top edge at a given
+ *   x, in shed space. Level at the eave unless the caller says otherwise; a
+ *   Barn passes the underside of its roof, which is as high as a board can go
+ *   and leaves nothing showing between it and the fly.
+ * @param {number} [stock.floorY] the bottom edge. Flat, and on the floor.
+ * @returns {Array<{corner: string, face: string, outline: number[][],
+ *   position: number[], depth: number}>} outlines in the XZ-facing plane, to
+ *   extrude along Z from `position`
  */
 export function cornerBoards(shedWidth, shedLength, wallHeight, stock = {}) {
-	const { trimWidth = TRIM_WIDTH, trimThickness = TRIM_THICKNESS } = stock;
+	const {
+		trimWidth = TRIM_WIDTH,
+		trimThickness = TRIM_THICKNESS,
+		topAt = () => wallHeight,
+		floorY = 0,
+	} = stock;
 
 	const halfW = shedWidth / 2;
 	const halfL = shedLength / 2;
 	const w = trimWidth;
 	const t = trimThickness;
-	const y = wallHeight / 2;
+
+	// Bottom flat on the floor, top wherever the roof puts it. Walked as a
+	// quad from the inner bottom corner, so the two ends stay opposite edges
+	// however the top slopes.
+	const board = (inner, outer) => [
+		[inner, floorY],
+		[outer, floorY],
+		[outer, topAt(outer)],
+		[inner, topAt(inner)],
+	];
 
 	// sx picks the right (+1) or left (-1) wall, sz the front (+1) or back (-1).
 	const quadrants = [
@@ -150,22 +265,25 @@ export function cornerBoards(shedWidth, shedLength, wallHeight, stock = {}) {
 		{
 			corner,
 			face,
-			position: [sx * (halfW + t / 2), y, sz * (halfL - w / 2)],
-			size: [t, wallHeight, w],
+			outline: board(sx * halfW, sx * (halfW + t)),
+			position: [0, 0, sz > 0 ? halfL - w : -halfL],
+			depth: w,
 		},
 		// On the front or back wall: face width running across X, far enough
 		// past the corner to lap the side board's outer face at halfW + t.
 		{
 			corner,
 			face: endFace,
-			position: [sx * (halfW + (t - w) / 2), y, sz * (halfL + t / 2)],
-			size: [w + t, wallHeight, t],
+			outline: board(sx * (halfW - w), sx * (halfW + t)),
+			position: [0, 0, sz > 0 ? halfL : -(halfL + t)],
+			depth: t,
 		},
 	]);
 }
 
 /**
- * The fascia the Gable's roof edge is boxed in with — two rakes and two eaves.
+ * The fascia the Gable's roof edge is boxed in with — a rake on each gable
+ * end, and an eave down each side.
  *
  * These have to be worked out from the roof, not from the wall, and that is why
  * they moved here. The roof became a slab that runs `overhang` past all four
@@ -174,11 +292,22 @@ export function cornerBoards(shedWidth, shedLength, wallHeight, stock = {}) {
  * projection, invisible. The photographs show the opposite: the rake board is
  * the widest thing on that edge and the roof panel is a line above it.
  *
- * A board covers the slab's cut edge, so it is `roofThickness` on the face and
- * `TRIM_THICKNESS` deep, and it stands just outside the surface it covers.
+ * The rake comes back as **one mitred outline per end** rather than two boards
+ * (see `mitredBand`). Two boxes could be given the right length and still not
+ * meet: cut square across their own axes they left a wedge open above the apex
+ * and crossed below it.
+ *
+ * Rake and eave are the same board turning the corner, so the three numbers
+ * that decide where their faces sit are shared rather than chosen twice: both
+ * hang `eaveFasciaDrop` below the roof's edge, both are `roofThickness` deep
+ * measured **plumb**, and the rake's plumb end lands in the plane the eave
+ * board's inner face occupies. The eave then runs a board's thickness past the
+ * slab at each end to lap that end — the fascia's counterpart of the lap at a
+ * corner board.
  *
  * @param roofHeight rise at the wall, which is what the Peak Height quotes
- * @returns boards as `{ id, position, size, rotation }`, ready for a mesh
+ * @returns {{rakes: object[], eaves: object[]}} rakes as `{ id, outline,
+ *   position, depth }` to extrude, eaves as `{ id, position, size, rotation }`
  */
 export function gableFasciaBoards(
 	shedWidth,
@@ -190,6 +319,8 @@ export function gableFasciaBoards(
 	const halfW = shedWidth / 2;
 	const halfL = shedLength / 2;
 	const slope = roofHeight / halfW;
+	// Plumb feet per foot measured across the rake, and back again.
+	const perRun = Math.hypot(1, slope);
 
 	// Where the slab actually ends. `y = 0` in the roof profile is the eave at
 	// the wall, so the overhang tip hangs BELOW the top plate by its own run.
@@ -197,46 +328,47 @@ export function gableFasciaBoards(
 	const outerZ = halfL + overhang;
 	const tipDrop = overhang * slope;
 
-	// Rake: ridge to eave tip, along the slope, on the outside of the gable
-	// end. The two boards are mitred at the apex — cut square they crossed in
-	// an X and each poked past the opposing slope's silhouette — and the whole
-	// board hangs RAKE_REVEAL below the surface, the reveal the J-channel's
-	// metal face fills. Perpendicular, not plumb: a plumb-cut slab is thinner
-	// perpendicular than the board, and hanging the board a plumb half-slab
-	// down rose its top corner through the roof plane.
-	const rakeZ = outerZ + trimThickness / 2;
-	const rakeTop = [
-		[-outerX, -tipDrop],
-		[0, roofHeight],
-		[outerX, -tipDrop],
-	];
-	const rakeRuns = mitredRuns(rakeTop, RAKE_REVEAL + roofThickness / 2);
+	// Rake: eave tip to eave tip over the apex, on the outside of the gable end,
+	// hanging RAKE_REVEAL below the surface — the reveal the J-channel's metal
+	// face fills. The face is `roofThickness` measured STRAIGHT DOWN, because
+	// that is how much slab edge there is to cover: `slabFrom` drops the top line
+	// vertically. Measured across the board instead it hung a further 1/cos deep
+	// and finished below the eave fascia it has to meet.
+	const rakeOutline = mitredBand(
+		[
+			[-outerX, -tipDrop],
+			[0, roofHeight],
+			[outerX, -tipDrop],
+		],
+		{ reveal: RAKE_REVEAL, faceWidth: roofThickness / perRun }
+	);
 
 	const rakes = [
-		['front-left', 0, +rakeZ],
-		['front-right', 1, +rakeZ],
-		['back-left', 0, -rakeZ],
-		['back-right', 1, -rakeZ],
-	].map(([id, run, z]) => ({
-		id: `rake-${id}`,
-		position: [rakeRuns[run].mid[0], wallHeight + rakeRuns[run].mid[1], z],
-		size: [rakeRuns[run].len, roofThickness, trimThickness],
-		rotation: [0, 0, rakeRuns[run].rot],
-	}));
+		{
+			id: 'rake-front',
+			outline: rakeOutline,
+			position: [0, wallHeight, outerZ],
+			depth: trimThickness,
+		},
+		{
+			id: 'rake-back',
+			outline: rakeOutline,
+			position: [0, wallHeight, -outerZ - trimThickness],
+			depth: trimThickness,
+		},
+	];
 
-	// Eave: level, the full length of the slab, so it meets both rake ends.
-	// Dropped a small reveal below the slab's tip corner — flush with it the
-	// two coplanar edges fought for the same pixels, and the photographs show
-	// the metal overhanging the fascia with a drip anyway.
-	const eaveY = wallHeight - tipDrop - EAVE_REVEAL - roofThickness / 2;
+	// Eave: level, and a board's thickness past the slab at each end so it laps
+	// the rake's plumb cut instead of leaving the corner of the overhang open.
+	const eaveY = wallHeight - tipDrop - eaveFasciaDrop(slope) - roofThickness / 2;
 	const eaves = [-1, +1].map((sx) => ({
 		id: sx < 0 ? 'eave-left' : 'eave-right',
 		position: [sx * (outerX + trimThickness / 2), eaveY, 0],
-		size: [trimThickness, roofThickness, shedLength + 2 * overhang],
+		size: [trimThickness, roofThickness, shedLength + 2 * (overhang + trimThickness)],
 		rotation: [0, 0, 0],
 	}));
 
-		return [...rakes, ...eaves];
+	return { rakes, eaves };
 }
 
 /**
@@ -249,34 +381,39 @@ export function gableFasciaBoards(
  * measured as one band; the photographs split it 1.5 in of white under ~2 in
  * of metal.
  *
- * The runs are mitred at the Knuckles and the ridge — cut square they jutted
- * past the roof's silhouette at every joint.
+ * One outline per end, mitred at both Knuckles and the ridge and finished flat
+ * at the eave tips. It was four boxes per end, which no length can make meet: a
+ * square-cut end poked past the roof's silhouette at every joint.
+ *
+ * The flat bottom is the whole difference a 20:12 slope makes. A plumb cut on a
+ * run that steep leaves a long point below the band, and the fly hung two and a
+ * half inches of paint below the roof it is tucked under. It stops where the
+ * metal stops: `roofThickness` below the eave tip is the slab's own underside.
  *
  * @param topLine slab top surface from `gambrelRoofTopLine`, eave tip to eave
  *   tip over both Knuckles, in wall-relative coordinates
  */
 export function barnRakeFlashing(topLine, shedLength, wallHeight, {
 	overhang,
+	roofThickness,
 	reveal = RAKE_REVEAL,
 	faceWidth = FLY_FACE,
 	thickness = TRIM_THICKNESS,
 } = {}) {
-	const names = ['left-lower', 'left-upper', 'right-upper', 'right-lower'];
-	const runs = mitredRuns(topLine, reveal + faceWidth / 2);
+	const outline = mitredBand(topLine, {
+		reveal,
+		faceWidth,
+		endFloor: topLine[0][1] - roofThickness,
+	});
 
-	const halfL = shedLength / 2;
 	// Against the slab's end cap face, which the slab carries `overhang` past
 	// the end siding. The J-channel sits just proud of this, lapping it.
-	const z = halfL + overhang + thickness / 2;
+	const z = shedLength / 2 + overhang;
 
-	return ['front', 'back'].flatMap((side) =>
-		runs.map(({ mid, len, rot }, i) => ({
-			id: `rake-${side}-${names[i]}`,
-			position: [mid[0], wallHeight + mid[1], side === 'front' ? z : -z],
-			size: [len, faceWidth, thickness],
-			rotation: [0, 0, rot],
-		}))
-	);
+	return [
+		{ id: 'rake-front', outline, position: [0, wallHeight, z], depth: thickness },
+		{ id: 'rake-back', outline, position: [0, wallHeight, -z - thickness], depth: thickness },
+	];
 }
 
 /**
@@ -357,9 +494,9 @@ export function gableCornerBoxes(shedWidth, shedLength, wallHeight, roofHeight, 
 	const halfL = shedLength / 2;
 	const slope = roofHeight / halfW;
 	const tipDrop = overhang * slope;
-	// Same datum as the eave fascia: the slab's edge at the tip, dropped the
-	// same EAVE_REVEAL so the two never rise past the metal.
-	const y = wallHeight - tipDrop - EAVE_REVEAL - roofThickness / 2;
+	// Same datum as the eave fascia, which is the point: the box closes the
+	// corner between that board and the rake, so it hangs off the same line.
+	const y = wallHeight - tipDrop - eaveFasciaDrop(slope) - roofThickness / 2;
 
 	return [
 		['front-right', +1, +1],
@@ -420,10 +557,11 @@ export function roofRidgeCap(peakY, slope, shedLength, wallHeight, {
  * the metal cap the photographs show on every edge: J_CHANNEL_FACE of roof
  * metal, lapping J_CHANNEL_LAP over the panel so the roof's end silhouette
  * stays metal, with the painted fly or fascia starting where it ends. It is
- * the proudest thing on the edge — it goes on over the fly. The runs are
- * mitred like the fly's, and the face is deep enough to cover the knuckle
- * flashing's end where that dies into the edge. Roof metal, not trim —
- * render it in the roof colour.
+ * the proudest thing on the edge — it goes on over the fly. It is one mitred
+ * band per end like the fly it covers, so the two stay in register at every
+ * break, and the face is deep enough to cover the knuckle flashing's end
+ * where that dies into the edge. Roof metal, not trim — render it in the roof
+ * colour.
  *
  * @param topLine slab top surface from `gableRoofTopLine` or
  *   `gambrelRoofTopLine`, eave tip to eave tip, wall-relative
@@ -434,17 +572,15 @@ export function rakeJChannel(topLine, shedLength, wallHeight, {
 	lap = J_CHANNEL_LAP,
 	thickness = 0.03,
 } = {}) {
-	const runs = mitredRuns(topLine, faceWidth / 2 - lap);
-	const halfL = shedLength / 2;
-	// Proud of the fly it laps: slab end, then the fly's stock, then this.
-	const z = halfL + overhang + TRIM_THICKNESS + thickness / 2;
+	// A negative reveal is the lap: the channel starts above the panel surface
+	// and covers down past it, so the roof's end silhouette stays metal.
+	const outline = mitredBand(topLine, { reveal: -lap, faceWidth });
 
-	return ['front', 'back'].flatMap((side) =>
-		runs.map(({ mid, len, rot }, i) => ({
-			id: `j-channel-${side}-${i}`,
-			position: [mid[0], wallHeight + mid[1], side === 'front' ? z : -z],
-			size: [len, faceWidth, thickness],
-			rotation: [0, 0, rot],
-		}))
-	);
+	// Proud of the fly it laps: slab end, then the fly's stock, then this.
+	const z = shedLength / 2 + overhang + TRIM_THICKNESS;
+
+	return [
+		{ id: 'j-channel-front', outline, position: [0, wallHeight, z], depth: thickness },
+		{ id: 'j-channel-back', outline, position: [0, wallHeight, -z - thickness], depth: thickness },
+	];
 }

--- a/frontend/src/utils/trimGeometry.test.js
+++ b/frontend/src/utils/trimGeometry.test.js
@@ -7,9 +7,11 @@ import {
 	gableCornerBoxes,
 	roofRidgeCap,
 	rakeJChannel,
+	bandUnderside,
+	eaveFasciaDrop,
 	RAKE_REVEAL,
-	EAVE_REVEAL,
 	FLY_FACE,
+	J_CHANNEL_FACE,
 	J_CHANNEL_LAP,
 	TRIM_THICKNESS,
 	TRIM_WIDTH,
@@ -27,9 +29,50 @@ const halfL = LENGTH / 2;  // 10.0 — the plane the front/back siding sits on
 
 const boards = () => cornerBoards(WIDTH, LENGTH, WALL_HEIGHT);
 
-/** Axis-aligned bounds of a board, as [min, max] per axis. */
+/**
+ * How far below a line a point lies, measured perpendicular to it.
+ *
+ * Signed via the cross product, so a point lapped OVER the line — the way the
+ * J-channel is bent over the panel edge — comes out negative. The line is
+ * given by two of its own points, never by the offset the code applied.
+ */
+const belowLine = ([ax, ay], [bx, by], [px, py]) =>
+	((bx - ax) * (ay - py) - (by - ay) * (ax - px)) / Math.hypot(bx - ax, by - ay);
+
+/**
+ * Read a band's outline back as its two edges and its two end corners.
+ *
+ * `mitredBand` walks the top edge left to right, turns the right end, walks the
+ * bottom edge back, and turns the left end. An end is a single plumb cut and
+ * contributes no point of its own, unless a flat bottom takes the corner off
+ * it, which adds one. So the caller says how many points the surface line had
+ * and the rest follows.
+ */
+const edgesOf = (outline, points) => {
+	const perEnd = (outline.length - 2 * points) / 2;
+	return {
+		top: outline.slice(0, points),
+		bottom: outline.slice(points + perEnd, 2 * points + perEnd).reverse(),
+		// Left end first, to read the same way round as the edges do.
+		corners: perEnd ? [outline.at(-1), outline[points]] : [],
+	};
+};
+
+/** Axis-aligned bounds of a box, as [min, max] per axis. */
 const boundsOf = ({ position, size }) =>
 	position.map((c, axis) => [c - size[axis] / 2, c + size[axis] / 2]);
+
+/**
+ * The same, for a piece given as an outline extruded along Z.
+ *
+ * X and Y come from the outline; Z is the extrusion, which runs from the
+ * position forwards.
+ */
+const outlineBounds = ({ outline, position, depth }) => [
+	[Math.min(...outline.map(([x]) => x)), Math.max(...outline.map(([x]) => x))],
+	[Math.min(...outline.map(([, y]) => y)), Math.max(...outline.map(([, y]) => y))],
+	[position[2], position[2] + depth],
+];
 
 /**
  * How much of a board lies inside the wall volume.
@@ -41,7 +84,7 @@ const boundsOf = ({ position, size }) =>
  */
 const volumeInsideWalls = (board) => {
 	const envelope = [[-halfW, halfW], [0, WALL_HEIGHT], [-halfL, halfL]];
-	return boundsOf(board).reduce((volume, [lo, hi], axis) => {
+	return outlineBounds(board).reduce((volume, [lo, hi], axis) => {
 		const [eLo, eHi] = envelope[axis];
 		return volume * Math.max(0, Math.min(hi, eHi) - Math.max(lo, eLo));
 	}, 1);
@@ -80,7 +123,7 @@ describe('cornerBoards', () => {
 	it('lands each board against the siding it is nailed to', () => {
 		// Proud of the wall, but touching it — a gap would show daylight.
 		for (const board of boards()) {
-			const [[minX, maxX], , [minZ, maxZ]] = boundsOf(board);
+			const [[minX, maxX], , [minZ, maxZ]] = outlineBounds(board);
 			if (board.face === 'front') expect(minZ).toBeCloseTo(halfL, 10);
 			if (board.face === 'back') expect(maxZ).toBeCloseTo(-halfL, 10);
 			if (board.face === 'right') expect(minX).toBeCloseTo(halfW, 10);
@@ -98,11 +141,11 @@ describe('cornerBoards', () => {
 		// 6.0 + 0.0625. The front board has to reach that same x to hide the
 		// side board's end grain, and it starts a board's width back from the
 		// corner at 6.0 - 0.333.
-		const [[frontMinX, frontMaxX]] = boundsOf(front);
+		const [[frontMinX, frontMaxX]] = outlineBounds(front);
 		expect(frontMaxX).toBeCloseTo(halfW + TRIM_THICKNESS, 10);
 		expect(frontMinX).toBeCloseTo(halfW - TRIM_WIDTH, 10);
 
-		const [[sideMinX, sideMaxX], , [sideMinZ, sideMaxZ]] = boundsOf(side);
+		const [[sideMinX, sideMaxX], , [sideMinZ, sideMaxZ]] = outlineBounds(side);
 		expect(sideMaxX).toBeCloseTo(halfW + TRIM_THICKNESS, 10);
 		expect(sideMinX).toBeCloseTo(halfW, 10);
 		// The side board stops at the front siding, where the front board takes over.
@@ -112,11 +155,44 @@ describe('cornerBoards', () => {
 
 	it('runs the boards floor to eave', () => {
 		for (const board of boards()) {
-			const [, [minY, maxY]] = boundsOf(board);
+			const [, [minY, maxY]] = outlineBounds(board);
 			expect(minY).toBeCloseTo(0, 10);
 			expect(maxY).toBeCloseTo(WALL_HEIGHT, 10);
 		}
 	});
+
+	it('keeps the bottom flat on the floor whatever the top does', () => {
+		// The top is cut to fit the roof and the bottom never is: it sits on
+		// the deck, which is what y = 0 means here.
+		for (const board of cornerBoards(WIDTH, LENGTH, WALL_HEIGHT, {
+			topAt: (x) => WALL_HEIGHT - Math.abs(x),
+		})) {
+			const bottom = board.outline.filter(([, y]) => y === 0);
+			expect(bottom).toHaveLength(2);
+			expect(bottom[0][1]).toBe(bottom[1][1]);
+		}
+	});
+
+	it('cuts the top to the line it is given, across the board', () => {
+		// A Barn's gambrel drops 20 in every 12 across a corner board, so there
+		// is no level cut that both meets the fly and stays out of the roof.
+		// The board takes its top from the line, at each of its own edges.
+		const topAt = (x) => WALL_HEIGHT - 0.5 * Math.abs(x);
+		const all = cornerBoards(WIDTH, LENGTH, WALL_HEIGHT, { topAt });
+
+		for (const board of all) {
+			for (const [x, y] of board.outline) {
+				if (y !== 0) expect(y).toBeCloseTo(topAt(x), 10);
+			}
+		}
+
+		// And that really is a slope, not a level cut at some average.
+		const front = all.find((b) => b.corner === 'front-right' && b.face === 'front');
+		const [, [minY, maxY]] = outlineBounds(front);
+		expect(maxY - minY).toBeGreaterThan(0);
+		expect(maxY).toBeCloseTo(topAt(halfW - TRIM_WIDTH), 10);
+	});
+
 });
 
 // ── The fascia that boxes the roof slab's cut edge ───────────────────────────
@@ -132,93 +208,113 @@ describe('gableFasciaBoards', () => {
 	const OVERHANG = 0.5;
 	const THICK = 0.333;
 
-	const boards = gableFasciaBoards(WIDTH, LENGTH, WALL_HEIGHT, ROOF_HEIGHT, {
+	// A 6:12 rake: 1 ft along the slope is hypot(1, 0.5) ft measured plumb, and
+	// the overhang tip hangs half its own run below the eave at the wall.
+	const PER_RUN = Math.hypot(1, 0.5);
+	const OUTER_X = halfW + OVERHANG; // 6.5
+	const TIP_DROP = OVERHANG * 0.5;  // 0.25
+
+	const { rakes, eaves } = gableFasciaBoards(WIDTH, LENGTH, WALL_HEIGHT, ROOF_HEIGHT, {
 		overhang: OVERHANG,
 		roofThickness: THICK,
 	});
-	const by = (id) => boards.find((b) => b.id === id);
+	const by = (id) => [...rakes, ...eaves].find((b) => b.id === id);
 
-	it('gives four rakes and two eaves', () => {
-		expect(boards).toHaveLength(6);
-		expect(boards.filter((b) => b.id.startsWith('rake-'))).toHaveLength(4);
-		expect(boards.filter((b) => b.id.startsWith('eave-'))).toHaveLength(2);
+	it('gives one mitred rake per gable end and an eave down each side', () => {
+		expect(rakes.map((r) => r.id)).toEqual(['rake-front', 'rake-back']);
+		expect(eaves.map((e) => e.id).sort()).toEqual(['eave-left', 'eave-right']);
 	});
 
 	it('stands the rake outside the roof, not on the wall it used to sit on', () => {
 		// The slab runs to halfL + overhang. A board on the gable end plane at
 		// halfL is behind that and cannot be seen.
-		expect(by('rake-front-left').position[2]).toBeGreaterThan(halfL + OVERHANG);
-		expect(by('rake-back-left').position[2]).toBeLessThan(-(halfL + OVERHANG));
+		expect(by('rake-front').position[2]).toBeCloseTo(halfL + OVERHANG, 10);
+		expect(by('rake-back').position[2]).toBeCloseTo(
+			-(halfL + OVERHANG) - TRIM_THICKNESS,
+			10
+		);
+		for (const r of rakes) expect(r.depth).toBeCloseTo(TRIM_THICKNESS, 10);
 	});
 
-	it('runs the rake the full slope, tip to the mitre under the apex', () => {
-		// Rise from the tip to the ridge is the wall rise plus what the overhang
-		// drops below the eave: 3 + 0.5 x (3/6) = 3.25, over a run of 6.5 — less
-		// the mitre: the peak is a convex corner, so centre lines offset toward
-		// its inside meet offset x slope SHORT of the apex foot, which is
-		// exactly why the boards no longer cross in an X there.
-		const rake = by('rake-front-right');
-		const offset = RAKE_REVEAL + THICK / 2;
-		expect(rake.size[0]).toBeCloseTo(Math.hypot(6.5, 3.25) - offset * 0.5, 10);
-	});
-
-	it('mitres the two rakes to a single point under the apex', () => {
+	it('mitres the two runs to a single point on the plumb line under the apex', () => {
 		// Cut square they crossed in an X at the peak, each poking past the
-		// opposing slope's silhouette. Both boards' apex ends must land on the
-		// same point: straight below the apex, offset / cos(pitch angle) down.
-		const endOf = (b, sign) => [
-			b.position[0] + sign * Math.cos(b.rotation[2]) * (b.size[0] / 2),
-			b.position[1] + sign * Math.sin(b.rotation[2]) * (b.size[0] / 2),
-		];
-		const left = endOf(by('rake-front-left'), +1);
-		const right = endOf(by('rake-front-right'), -1);
-		expect(left[0]).toBeCloseTo(right[0], 10);
-		expect(left[1]).toBeCloseTo(right[1], 10);
-		const offset = RAKE_REVEAL + THICK / 2;
-		expect(left[0]).toBeCloseTo(0, 10);
-		expect(left[1]).toBeCloseTo(WALL_HEIGHT + 3 - offset / (6.5 / Math.hypot(6.5, 3.25)), 10);
+		// opposing slope's silhouette. Offset the same distance from two slopes
+		// that are mirror images, the edges can only meet on the axis of
+		// symmetry — and a perpendicular drop of RAKE_REVEAL is PER_RUN times
+		// as far measured straight down.
+		const { top, bottom } = edgesOf(by('rake-front').outline, 3);
+		expect(top).toHaveLength(3);
+
+		expect(top[1][0]).toBeCloseTo(0, 10);
+		expect(top[1][1]).toBeCloseTo(ROOF_HEIGHT - RAKE_REVEAL * PER_RUN, 10);
+		expect(bottom[1][0]).toBeCloseTo(0, 10);
+		expect(bottom[1][1]).toBeCloseTo(top[1][1] - THICK, 10);
 	});
 
-	it('pitches the rake at the roof pitch', () => {
-		// Not the wall-to-ridge angle: the board follows the slab, which carries
-		// on past the wall at the same pitch.
-		const rake = by('rake-front-right');
-		expect(rake.rotation[2]).toBeCloseTo(-Math.atan2(3.25, 6.5), 10);
-		expect(by('rake-front-left').rotation[2]).toBeCloseTo(Math.atan2(3.25, 6.5), 10);
+	it('cuts both ends plumb, at the slab edge', () => {
+		const { top, bottom } = edgesOf(by('rake-front').outline, 3);
+		expect(top[0][0]).toBeCloseTo(-OUTER_X, 10);
+		expect(bottom[0][0]).toBeCloseTo(-OUTER_X, 10);
+		expect(top[2][0]).toBeCloseTo(OUTER_X, 10);
+		expect(bottom[2][0]).toBeCloseTo(OUTER_X, 10);
+	});
+
+	it('covers the slab edge, which is roofThickness measured straight down', () => {
+		// The slab is cut plumb — `slabFrom` drops the top line vertically — so
+		// the board over it is roofThickness plumb, not roofThickness across the
+		// board. Across, it hung a further 1/cos deep and finished below the
+		// eave fascia it meets.
+		const { top, bottom } = edgesOf(by('rake-front').outline, 3);
+		for (let i = 0; i < top.length; i++) {
+			expect(top[i][1] - bottom[i][1]).toBeCloseTo(THICK, 10);
+		}
+	});
+
+	it('hangs the rake below the metal, by the reveal the J-channel fills', () => {
+		// Perpendicular distance from the band's top edge down to the slope it
+		// follows: the front-right run goes (0, 3) at the ridge to (6.5, -0.25)
+		// at the tip.
+		const { top } = edgesOf(by('rake-front').outline, 3);
+		expect(belowLine([0, ROOF_HEIGHT], [OUTER_X, -TIP_DROP], top[2])).toBeCloseTo(
+			RAKE_REVEAL,
+			10
+		);
 	});
 
 	it('hangs the eave below the top plate, where the rafter tail is', () => {
 		// y = 0 in the roof profile is the eave AT THE WALL, so the tip is a
-		// half-pitch-run lower — 0.25 ft here — and the board covers the slab.
+		// half-pitch-run lower, and the fascia hangs the rake's own reveal below
+		// that — measured plumb, because the board is level.
 		const eave = by('eave-right');
-		expect(eave.position[1]).toBeCloseTo(WALL_HEIGHT - 0.25 - EAVE_REVEAL - THICK / 2, 10);
+		expect(eave.position[1]).toBeCloseTo(
+			WALL_HEIGHT - TIP_DROP - RAKE_REVEAL * PER_RUN - THICK / 2,
+			10
+		);
+		expect(eaveFasciaDrop(0.5)).toBeCloseTo(RAKE_REVEAL * PER_RUN, 10);
 	});
 
-	it('runs the eave the whole length of the slab, so it meets both rakes', () => {
-		expect(by('eave-left').size[2]).toBeCloseTo(LENGTH + 2 * OVERHANG, 10);
+	it('meets the rake flush at the corner, top edge and bottom', () => {
+		// The whole point of tying the two reveals together: the rake's plumb
+		// cut and the eave board's end face have to be the same rectangle, or
+		// the fascia steps as it turns the corner. It stepped an inch and a half.
+		const { top, bottom } = edgesOf(by('rake-front').outline, 3);
+		const eave = by('eave-right');
+		expect(eave.position[1] + eave.size[1] / 2).toBeCloseTo(WALL_HEIGHT + top[2][1], 10);
+		expect(eave.position[1] - eave.size[1] / 2).toBeCloseTo(WALL_HEIGHT + bottom[2][1], 10);
 	});
 
-	it('keeps the rake board below the metal', () => {
-		// The board is rotated with the slope, and the slab is cut plumb — so a
-		// board hung a plumb half-slab down is thicker perpendicular than the
-		// slab is and its top corner rises through the roof plane. The top edge
-		// must sit RAKE_REVEAL perpendicular below the top surface instead. The
-		// front-right slope runs (0, 3) at the ridge to (6.5, -0.25) at the tip.
-		const b = by('rake-front-right');
-		const len = Math.hypot(6.5, 3.25);
-		const below =
-			(6.5 * (WALL_HEIGHT + (3 - 0.25) / 2 - b.position[1]) -
-				-3.25 * (6.5 / 2 - b.position[0])) /
-			len;
-		expect(below).toBeCloseTo(RAKE_REVEAL + THICK / 2, 10);
-	});
-
-	it('covers the slab edge, whatever the slab is', () => {
-		const thicker = gableFasciaBoards(WIDTH, LENGTH, WALL_HEIGHT, ROOF_HEIGHT, {
-			overhang: OVERHANG,
-			roofThickness: 0.5,
-		});
-		for (const b of thicker) expect(b.size[1]).toBeCloseTo(0.5, 10);
+	it('runs the eave past the slab at each end, so it laps the rake', () => {
+		// Stopping at the slab left the corner of the overhang open: nothing
+		// covered the board's thickness between the rake's plumb cut and the
+		// eave's own outer face.
+		expect(by('eave-left').size[2]).toBeCloseTo(
+			LENGTH + 2 * (OVERHANG + TRIM_THICKNESS),
+			10
+		);
+		const eave = by('eave-right');
+		expect(eave.position[2] + eave.size[2] / 2).toBeGreaterThanOrEqual(
+			by('rake-front').position[2] + by('rake-front').depth
+		);
 	});
 });
 
@@ -235,78 +331,144 @@ describe('barnRakeFlashing', () => {
 		[6 + 1 / 6, -5 / 18],
 	];
 	const OVERHANG = 2 / 12;
+	const THICK = 0.333;
 
 	const bands = barnRakeFlashing(TOPLINE, LENGTH, WALL_HEIGHT, {
 		overhang: OVERHANG,
+		roofThickness: THICK,
 	});
 	const by = (id) => bands.find((b) => b.id === id);
 
-	it('gives four runs on each end', () => {
-		expect(bands).toHaveLength(8);
-		expect(bands.filter((b) => b.id.startsWith('rake-front-'))).toHaveLength(4);
+	it('gives one band per end, four runs long', () => {
+		expect(bands.map((b) => b.id)).toEqual(['rake-front', 'rake-back']);
+		// Five points along the surface, so five along each edge of the band.
+		expect(edgesOf(by('rake-front').outline, 5).top).toHaveLength(5);
 	});
 
-	it('mitres consecutive runs to shared joints at the Knuckle and ridge', () => {
+	it('mitres the joints at both Knuckles and the ridge', () => {
 		// Cut square, each run's end jutted past the roof's silhouette at every
-		// joint. Mitred, the lower run's upper end and the upper run's lower end
-		// are the same point.
-		const endOf = (b, sign) => [
-			b.position[0] + sign * Math.cos(b.rotation[2]) * (b.size[0] / 2),
-			b.position[1] + sign * Math.sin(b.rotation[2]) * (b.size[0] / 2),
-		];
-		const pairs = [
-			['rake-front-left-lower', 'rake-front-left-upper'],
-			['rake-front-left-upper', 'rake-front-right-upper'],
-			['rake-front-right-upper', 'rake-front-right-lower'],
-		];
-		for (const [a, b] of pairs) {
-			const tail = endOf(by(a), +1);
-			const head = endOf(by(b), -1);
-			expect(tail[0]).toBeCloseTo(head[0], 10);
-			expect(tail[1]).toBeCloseTo(head[1], 10);
+		// joint. Mitred, the joint is a single point on both edges, and it lies
+		// on the bisector — which for the ridge is the plumb line.
+		const { top, bottom } = edgesOf(by('rake-front').outline, 5);
+		expect(top[2][0]).toBeCloseTo(0, 10);
+		expect(bottom[2][0]).toBeCloseTo(0, 10);
+
+		// Every interior joint sits strictly inside the roof, below the surface
+		// point it mitres, and the band never doubles back on itself.
+		for (let i = 1; i < top.length - 1; i++) {
+			expect(top[i][1]).toBeLessThan(TOPLINE[i][1]);
+			expect(top[i][0]).toBeGreaterThan(top[i - 1][0]);
 		}
 	});
 
-	it('lies at the pitch of the run it covers', () => {
-		// 20:12 below the knuckle, 4:12 above it, and the lower one is steeper —
-		// a barn whose lower slope is the shallow one is not a barn.
-		const lower = by('rake-front-left-lower').rotation[2];
-		const upper = by('rake-front-left-upper').rotation[2];
-		expect(Math.tan(lower)).toBeCloseTo(20 / 12, 10);
-		expect(Math.tan(upper)).toBeCloseTo(4 / 12, 10);
-		expect(lower).toBeGreaterThan(upper);
-	});
-
 	it('lies against the slab end cap, which runs the overhang past the siding', () => {
-		const z = halfL + OVERHANG + TRIM_THICKNESS / 2;
-		expect(by('rake-front-left-lower').position[2]).toBeCloseTo(z, 10);
-		expect(by('rake-back-left-lower').position[2]).toBeCloseTo(-z, 10);
+		expect(by('rake-front').position[2]).toBeCloseTo(halfL + OVERHANG, 10);
+		expect(by('rake-back').position[2]).toBeCloseTo(
+			-(halfL + OVERHANG) - TRIM_THICKNESS,
+			10
+		);
+		for (const b of bands) expect(b.depth).toBeCloseTo(TRIM_THICKNESS, 10);
 	});
 
 	it('keeps every scrap of white below the metal, on both slopes', () => {
-		// Point-line distance from the band's centre to its own run: the whole
-		// band lies RAKE_REVEAL + half a face below the top surface. Signed via
-		// the cross product, so a band lapped OVER the edge comes out negative.
-		for (const [, [x1, y1], [x2, y2]] of [
-			['lower', TOPLINE[0], TOPLINE[1]],
-			['upper', TOPLINE[1], TOPLINE[2]],
-		]) {
-			const id = y2 > y1 && x2 === 0 ? 'rake-front-left-upper' : 'rake-front-left-lower';
-			const b = by(id);
-			const len = Math.hypot(x2 - x1, y2 - y1);
-			const below =
-				((x2 - x1) * (WALL_HEIGHT + (y1 + y2) / 2 - b.position[1]) -
-					(y2 - y1) * ((x1 + x2) / 2 - b.position[0])) /
-				len;
-			expect(below).toBeCloseTo(RAKE_REVEAL + FLY_FACE / 2, 10);
+		// Point-line distance from the band's top edge to the run it follows.
+		// Signed via the cross product, so a band lapped OVER the edge comes out
+		// negative — the fly goes under the panel, never over it.
+		const { top } = edgesOf(by('rake-front').outline, 5);
+		for (const [i, a] of TOPLINE.slice(0, -1).entries()) {
+			expect(belowLine(a, TOPLINE[i + 1], top[i])).toBeCloseTo(RAKE_REVEAL, 10);
 		}
 	});
 
 	it('shows a flat 2x4 on the face, not a 4 in board', () => {
 		// 1.5 in: on `barn_barndoors.jpg` the white under the metal is 5-6 px at
 		// 3.4 px/in. The 4 in it used to be was the whole white-plus-metal stack
-		// measured as one band.
-		for (const b of bands) expect(b.size[1]).toBeCloseTo(FLY_FACE, 10);
+		// measured as one band. Perpendicular to each run, so the flat bottom
+		// that shortens the end run cannot flatter the answer.
+		const { bottom } = edgesOf(by('rake-front').outline, 5);
+		for (const [i, a] of TOPLINE.slice(0, -1).entries()) {
+			expect(belowLine(a, TOPLINE[i + 1], bottom[i])).toBeCloseTo(
+				RAKE_REVEAL + FLY_FACE,
+				10
+			);
+		}
+	});
+
+	it('finishes the fly flat where the metal stops', () => {
+		// A plumb cut on a 20:12 run leaves a long point below the band: the
+		// bottom edge reached the eave two and a half inches under the slab's own
+		// underside, which is where the metal stops. On the photographs the white
+		// ends in a level foot and the corner board takes over below it.
+		const { bottom, corners } = edgesOf(by('rake-front').outline, 5);
+		const floor = TOPLINE[0][1] - THICK;
+		const [left, right] = corners;
+
+		// The level cut meets the plumb one at the outer edge, on both ends.
+		expect(left[0]).toBeCloseTo(TOPLINE[0][0], 10);
+		expect(right[0]).toBeCloseTo(TOPLINE[4][0], 10);
+		expect(left[1]).toBeCloseTo(floor, 10);
+		expect(right[1]).toBeCloseTo(floor, 10);
+
+		// The flat runs back inboard from it, and no part of the band is below.
+		expect(bottom[0][1]).toBeCloseTo(floor, 10);
+		expect(bottom[0][0]).toBeGreaterThan(TOPLINE[0][0]);
+		for (const [, y] of by('rake-front').outline) {
+			expect(y).toBeGreaterThanOrEqual(floor - 1e-12);
+		}
+	});
+
+	it('leaves a plain plumb end where nothing hangs below the roof', () => {
+		// The cut is a fix for the Barn's steep lower slope, not a new rule for
+		// every band: a slab thick enough to reach past the fly leaves the end
+		// alone, and the outline goes back to two points per edge and no corner.
+		const [flat] = barnRakeFlashing(TOPLINE, LENGTH, WALL_HEIGHT, {
+			overhang: OVERHANG,
+			roofThickness: 2,
+		});
+		expect(edgesOf(flat.outline, 5).corners).toEqual([]);
+	});
+});
+
+describe('bandUnderside', () => {
+	// The same 12 ft barn at 20:12 over 4:12 with a 2 in overhang.
+	const TOPLINE = [
+		[-6 - 1 / 6, -5 / 18],
+		[-5, 5 / 3],
+		[0, 10 / 3],
+		[5, 5 / 3],
+		[6 + 1 / 6, -5 / 18],
+	];
+
+	it('follows the run the x falls on, a whole band below it', () => {
+		const under = bandUnderside(TOPLINE, { reveal: RAKE_REVEAL, faceWidth: FLY_FACE });
+		// One point on the steep lower run and one on the shallow upper run,
+		// each checked perpendicular to the run it belongs to.
+		expect(belowLine(TOPLINE[0], TOPLINE[1], [-5.5, under(-5.5)])).toBeCloseTo(
+			RAKE_REVEAL + FLY_FACE,
+			10
+		);
+		expect(belowLine(TOPLINE[1], TOPLINE[2], [-2, under(-2)])).toBeCloseTo(
+			RAKE_REVEAL + FLY_FACE,
+			10
+		);
+	});
+
+	it('gives the surface itself for a band of no width', () => {
+		// Which is how a Barn's corner boards find the roof they stop under:
+		// the surface, less the slab's thickness, which `slabFrom` drops plumb.
+		const surface = bandUnderside(TOPLINE, { reveal: 0, faceWidth: 0 });
+		for (const [x, y] of TOPLINE) expect(surface(x)).toBeCloseTo(y, 10);
+		// And between the points, on the line the two of them make.
+		expect(surface(-5.5)).toBeCloseTo(-5 / 18 + (6 + 1 / 6 - 5.5) * (20 / 12), 10);
+	});
+
+	it('carries the end runs on past the roof, for a board standing proud', () => {
+		// A corner board reaches trimThickness past the siding, which on the
+		// widest board is still inside the overhang — but the function must not
+		// fall over if a caller asks beyond the line's own ends.
+		const under = bandUnderside(TOPLINE, { reveal: RAKE_REVEAL, faceWidth: FLY_FACE });
+		expect(under(-7)).toBeLessThan(under(-6));
+		expect(Number.isFinite(under(7))).toBe(true);
 	});
 });
 
@@ -390,9 +552,11 @@ describe('gableCornerBoxes', () => {
 	});
 
 	it('hangs level with the eave fascia at the overhang tip', () => {
-		// The tip is a half-pitch-run below the top plate: 0.5 x (3/6) = 0.25.
+		// The tip is a half-pitch-run below the top plate: 0.5 x (3/6) = 0.25,
+		// and the fascia hangs the rake's own reveal below that — the box closes
+		// the corner between the two, so it has to come off the same line.
 		expect(by('corner-box-back-left').position[1]).toBeCloseTo(
-			WALL_HEIGHT - 0.25 - EAVE_REVEAL - THICK / 2,
+			WALL_HEIGHT - 0.25 - RAKE_REVEAL * Math.hypot(1, 0.5) - THICK / 2,
 			10
 		);
 	});
@@ -440,27 +604,40 @@ describe('rakeJChannel', () => {
 	const OVERHANG = 0.5;
 
 	const lips = rakeJChannel(TOPLINE, LENGTH, WALL_HEIGHT, { overhang: OVERHANG });
+	const by = (id) => lips.find((l) => l.id === id);
 
-	it('caps every run on both ends', () => {
-		expect(lips).toHaveLength(4);
-		expect(lips.filter((l) => l.id.startsWith('j-channel-front-'))).toHaveLength(2);
+	it('caps each end with one mitred band', () => {
+		expect(lips.map((l) => l.id)).toEqual(['j-channel-front', 'j-channel-back']);
+		expect(edgesOf(by('j-channel-front').outline, 3).top).toHaveLength(3);
 	});
 
-	it('sits just proud of the slab end cap', () => {
-		const front = lips.find((l) => l.id === 'j-channel-front-0');
-		expect(front.position[2]).toBeGreaterThan(halfL + OVERHANG);
+	it('sits proud of the fly it laps: slab end, the fly stock, then this', () => {
+		expect(by('j-channel-front').position[2]).toBeCloseTo(
+			halfL + OVERHANG + TRIM_THICKNESS,
+			10
+		);
+		expect(by('j-channel-back').position[2]).toBeLessThan(-(halfL + OVERHANG));
 	});
 
 	it('laps its own lap over the panel edge, so the silhouette stays metal', () => {
-		// The channel is bent over the panel: its centre sits half a face minus
-		// the lap below the run, leaving J_CHANNEL_LAP of metal above the
-		// surface and the rest covering the reveal down to the painted trim.
-		const l = lips.find((x) => x.id === 'j-channel-front-1');
-		const len = Math.hypot(6.5, 3.25);
-		const below =
-			(6.5 * (WALL_HEIGHT + (3 - 0.25) / 2 - l.position[1]) -
-				-3.25 * (6.5 / 2 - l.position[0])) /
-			len;
-		expect(below).toBeCloseTo(l.size[1] / 2 - J_CHANNEL_LAP, 10);
+		// The channel is bent over the panel: its top edge stands J_CHANNEL_LAP
+		// ABOVE the surface and its face covers the reveal down to the painted
+		// trim. Perpendicular distance to the front-right run, signed so that
+		// above the surface comes out negative.
+		const { top, bottom } = edgesOf(by('j-channel-front').outline, 3);
+		const perpTo = (p) => belowLine(TOPLINE[1], TOPLINE[2], p);
+
+		expect(perpTo(top[2])).toBeCloseTo(-J_CHANNEL_LAP, 10);
+		expect(perpTo(bottom[2])).toBeCloseTo(J_CHANNEL_FACE - J_CHANNEL_LAP, 10);
+		expect(perpTo(bottom[2])).toBeCloseTo(RAKE_REVEAL, 10);
+	});
+
+	it('mitres at the apex instead of butting two square ends there', () => {
+		const { top, bottom } = edgesOf(by('j-channel-front').outline, 3);
+		expect(top[1][0]).toBeCloseTo(0, 10);
+		expect(bottom[1][0]).toBeCloseTo(0, 10);
+		// The lap puts the top edge above the ridge, and the face below it.
+		expect(top[1][1]).toBeGreaterThan(3);
+		expect(bottom[1][1]).toBeLessThan(3);
 	});
 });


### PR DESCRIPTION
Closes #5
Closes #6

Both reference targets now render from the real `BarnShed` / `GableShed`, and the fidelity checklists on #5 and #6 are worked. What was left was the trim, and all of it came from one cause.

## The cause

A band that follows a roof edge — a rake fascia, a Barn's fly, the J-channel over either — was a run of boxes. A box is cut square across its own axis, so however carefully the centre lines were mitred, the **corners** still overshot. At the Gable's apex that left a wedge of daylight above the joint and crossing material below it; every Knuckle had the same defect in proportion to its angle.

`mitredBand` replaces `mitredRuns`. One closed outline per end: both edges are offset copies of the slab's top line, consecutive runs are intersected rather than butted, and the ends are cut **plumb** — the way `slabFrom` already cuts the slab. Outlines reach a mesh through the new `ExtrudedBand`, the same shape-then-extrude the roof itself uses. The ridge cap and the Knuckle flashing run along the shed rather than along an edge, so they stay boxes.

## What that turned up

**The Gable's two fascias didn't agree at the corner.** Each was picking its own numbers — a flat `0.04` eave reveal, and a rake measured across the board instead of plumb — and they landed 1.5in apart at the top edge, 2in at the bottom. Both now come off `eaveFasciaDrop` and `ROOF_THICKNESS` measured the way the slab is cut, so the plumb end and the eave board's end face are the same rectangle. The eave runs a board's thickness past the slab to lap that cut.

**A plumb end is right on a 6:12 and wrong on a Barn.** The steeper the run, the longer the point it leaves below the band, and the fly hung 2.42in of paint below the roof it is tucked under. `endFloor` cuts that end level at the slab's underside, leaving a 1.45in flat foot — the shape in `barn_barndoors.jpg`, with the corner board taking over below.

**Corner boards are cut to fit rather than run to the eave.** A Barn takes its top from the roof's underside: parallel to the fly, so it carries the gambrel's angle, and as high as a board can go before it enters the slab. Run level they buried their tops in the roof; cut on the fly's own lower edge, 2.42in under the slab, that much siding showed between the board and the fly from anywhere but dead on. The bottom is never cut — flat, and on the floor. A Gable leaves the default, level at the eave.

## Verification

- 187 tests pass. Expected values are trigonometry against the roof, never a second copy of what the code does. New coverage: the apex mitre lands on the plumb line; the rake's end and the eave's end face occupy the same rectangle; the fly's flat foot sits on the slab's underside with nothing below it; a slab thick enough to reach past the fly leaves a plain plumb end, so the level cut is a fix for the Barn's slope and not a new rule for every band; and `bandUnderside`, including that a band of no width is the surface itself.
- `npm run lint` holds at its 7 pre-existing errors.
- `npm run build` clean.
- Checked on screen on both Models, both pages — the suite mounts no React, so a green run is not evidence the app draws.

## Note on #6

Its body asks for the photo to be copied into `frontend/public/`. Not done: product photography stays out of the public repo, `reference/` stays gitignored, and `referencePhotos.js` loads it by name from there. No images in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpBS1UKbHqnu3ox13Rohte