### PR TITLE
test: freeze the reference renders and fail on a pixel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,15 @@ frontend/package-lock.json
 frontend/dist/
 frontend/.env*.local
 
+# Playwright. The frozen reference renders are generated on the machine that
+# checks them and are deliberately not committed, so a clone's first `npm run
+# test:e2e` writes its own baselines and fails; the second run is the one that
+# means something. `test-results/` is where a failure leaves the actual, the
+# expected and the diff to look at.
+frontend/e2e/__screenshots__/
+frontend/test-results/
+frontend/playwright-report/
+
 # IDE
 .vscode/
 .idea/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,7 @@ cd frontend
 npm run dev        # http://localhost:5173
 npm test           # vitest, single run
 npm run test:watch
+npm run test:e2e   # playwright: freeze-frame the two reference renders
 npm run build
 npm run lint       # 7 pre-existing errors — don't add more
 ```
@@ -369,8 +370,10 @@ hearing it twice. Note R3F puts `role`/`aria-label` on its own wrapper `<div>`, 
 
 ## Testing
 
-Tests live beside their subject as `*.test.js` and run in node — no jsdom, because every seam
-under test is non-React.
+There are two suites, and they never meet. `npm test` is vitest: tests live beside their subject
+as `*.test.js` and run in node — no jsdom, because every seam under test is non-React. `npm run
+test:e2e` is Playwright, and it lives in `frontend/e2e/` where vitest's `include`
+(`src/**/*.test.js`) cannot see it.
 
 | Seam | File |
 |---|---|
@@ -386,13 +389,57 @@ under test is non-React.
 | The save gate | `services/designApi.test.js` |
 | The shared catalog file | `utils/catalog.test.js` |
 | HTTP API | `main_test.go` |
+| The rendered reference Designs | `e2e/reference-match.spec.js` |
 
 Two rules that matter more than coverage:
 
 1. **Expected values come from an independent source** — trigonometry, or a price in
    `shed-options.md`. Never recompute the expectation the way the code does.
-2. **Nothing in the suite mounts React.** Tests and a clean build can both pass while the app is
-   broken on screen; that has already happened once. Run the app before believing a UI change.
+2. **Nothing in the vitest suite mounts React.** Tests and a clean build can both pass while the
+   app is broken on screen; that has already happened once. Run the app before believing a UI
+   change.
+
+### The pixel suite
+
+`e2e/reference-match.spec.js` is the answer to rule 2 for the one thing rule 2 cannot cover: the
+3D canvas is the whole output of the product and no vitest seam touches it. It drives the
+Reference Match page through the browser — nav, then the target button — and freezes the canvas
+of each approved reference Design, so a geometry or shader change that breaks fidelity fails
+here (issue #7).
+
+**It imports no component and no geometry function.** The seam is the `<canvas>` and only the
+`<canvas>`; the Reference Photo beside it is out of frame, because `reference/` is gitignored and
+a baseline holding the "no reference photo" placeholder would fail on every machine but the one
+that made it.
+
+**The baselines are not committed.** They are frozen renders rather than source, so each machine
+makes its own under `e2e/__screenshots__/`. A clone's first run therefore writes them and
+*fails*, and the second run is the first that means anything — loud rather than a silent pass.
+`npm run test:e2e:approve` re-freezes them, and is a sign-off, not a way past a red test.
+
+**Not one pixel may differ.** The render is bit-exact run to run on one machine, so a tolerance
+costs sensitivity and buys nothing: at `maxDiffPixelRatio: 0.002` — 961 of these 639 × 752
+pixels — widening trim stock by two inches passed on the barn. At zero, a fifth of an inch fails
+the gable. The floor is the render's own resolution, not the tolerance: the barn is a 53 ft
+three-quarter view and does not move at all until about a third of an inch. If a browser upgrade
+ever reddens both targets at once with no change in the tree, that is the one case for
+re-approving rather than debugging.
+
+Two things cost an afternoon each and are worth knowing:
+
+- **Wait for the canvas to reach its pane, not merely to exist.** The `<Canvas>` is keyed by
+  target id so R3F picks up each target's camera, so switching target remounts it, and a fresh
+  canvas spends a moment at the HTML default 300 × 150. A guard of `width * height > 0` returns
+  inside that moment and freezes a grey box.
+- **The page paints over its own canvas** — a badge top left, a caption bottom centre. Any check
+  that compares two regions has to take both clear of them, or it differs whether or not anything
+  was ever drawn, which is a green test that cannot fail.
+
+Issue #7 warns that headless WebGL needs `--use-gl=angle --use-angle=swiftshader
+--enable-unsafe-swiftshader`. It did not here — Playwright's bundled Chromium Headless Shell
+151 gives a `webgl2` context unaided, and forcing SwiftShader would only change the pixels the
+baselines are made of. Reach for those flags if `getContext('webgl2')` returns null on some other
+machine, and re-approve that machine's baselines when you do.
 
 ## Working in this repo
 

--- a/frontend/e2e/reference-match.spec.js
+++ b/frontend/e2e/reference-match.spec.js
@@ -1,0 +1,91 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Screenshot regression for the two approved reference Designs (issue #7).
+ *
+ * The suite drives the Reference Match page the way a person does — nav, then
+ * the target button — so the render under test is the real `BarnShed` /
+ * `GableShed` behind the real fixtures (ADR-0012). Nothing here imports a
+ * component or a geometry function; the seam is the `<canvas>` and only the
+ * `<canvas>`.
+ *
+ * The Reference Photo beside it is deliberately out of frame. `reference/` is
+ * gitignored, so a clone without the photos shows a placeholder there, and a
+ * baseline containing it would fail for a reason that has nothing to do with
+ * the shed.
+ */
+
+const TARGETS = ['barn-barndoors', 'gable-front'];
+
+/**
+ * Open Reference Match at one target and hand back its canvas, once it is
+ * actually drawing.
+ *
+ * **Wait for the canvas to reach its pane, not merely to exist.** Switching
+ * target remounts the `<Canvas>` — it is keyed by target id, so that R3F picks
+ * up the new camera — and a fresh canvas spends a moment at the HTML default
+ * 300 x 150 before R3F sizes it. Waiting on `width * height > 0` returns during
+ * that moment: the second target measured 300 x 150 where the first measured
+ * 639 x 752, and a baseline frozen through that guard is a grey box.
+ */
+async function reconstruction(page, targetId) {
+	await page.goto('/');
+	await page.getByRole('button', { name: 'Reference Match' }).click();
+	await page.getByRole('button', { name: targetId, exact: true }).click();
+
+	const canvas = page.locator('canvas');
+	await expect(canvas).toBeVisible();
+	await expect
+		.poll(() =>
+			canvas.evaluate((c) => {
+				const self = c.getBoundingClientRect();
+				const pane = c.parentElement.getBoundingClientRect();
+				return (
+					Math.round(self.width) === Math.round(pane.width) &&
+					Math.round(self.height) === Math.round(pane.height)
+				);
+			})
+		)
+		.toBe(true);
+	return canvas;
+}
+
+/** One square of the page, as PNG bytes. */
+const patch = (page, x, y, size) =>
+	page.screenshot({ clip: { x, y, width: size, height: size } });
+
+for (const targetId of TARGETS) {
+	test(`${targetId} draws a building rather than an empty canvas`, async ({ page }) => {
+		const canvas = await reconstruction(page, targetId);
+		const box = await canvas.boundingBox();
+
+		// Three equal squares, taken down the RIGHT edge and through the middle.
+		// The page paints a badge over the top left of the canvas and a caption
+		// over the bottom centre; a square holding either differs from its
+		// neighbour whether or not anything was ever drawn, which is a green
+		// test that cannot fail. Both sky squares are clear of them.
+		const size = 100;
+		const right = box.x + box.width - size - 8;
+		const skyTop = await patch(page, right, box.y + 8, size);
+		const skyBelow = await patch(page, right, box.y + 120, size);
+		const middle = await patch(
+			page,
+			box.x + box.width / 2 - size / 2,
+			box.y + box.height / 2 - size / 2,
+			size
+		);
+
+		// Empty sky is flat, so two squares of it encode to the same bytes.
+		// That is what a canvas with no WebGL context looks like everywhere.
+		expect(Buffer.compare(skyTop, skyBelow)).toBe(0);
+		// The middle of the frame is where the shed stands, so it is not flat.
+		expect(Buffer.compare(skyTop, middle)).not.toBe(0);
+	});
+}
+
+for (const targetId of TARGETS) {
+	test(`${targetId} matches its frozen render`, async ({ page }) => {
+		const canvas = await reconstruction(page, targetId);
+		await expect(canvas).toHaveScreenshot(`${targetId}.png`);
+	});
+}

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -26,4 +26,10 @@ export default defineConfig([
       'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
     },
   },
+  {
+    // The Playwright suite and its config run in the test runner, not in the
+    // browser: `Buffer` and `process` are node globals there.
+    files: ['e2e/**/*.js', 'playwright.config.js'],
+    languageOptions: { globals: globals.node },
+  },
 ])

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
 			},
 			"devDependencies": {
 				"@eslint/js": "^9.39.1",
+				"@playwright/test": "^1.62.1",
 				"@tailwindcss/postcss": "^4.1.17",
 				"@types/react": "^19.2.5",
 				"@types/react-dom": "^19.2.3",
@@ -992,6 +993,21 @@
 			},
 			"peerDependencies": {
 				"three": ">= 0.159.0"
+			}
+		},
+		"node_modules/@playwright/test": {
+			"version": "1.62.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+			"integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+			"dev": true,
+			"dependencies": {
+				"playwright": "1.62.1"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=20"
 			}
 		},
 		"node_modules/@react-three/drei": {
@@ -3733,6 +3749,50 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/playwright": {
+			"version": "1.62.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+			"integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+			"dev": true,
+			"dependencies": {
+				"playwright-core": "1.62.1"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.2"
+			}
+		},
+		"node_modules/playwright-core": {
+			"version": "1.62.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+			"integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+			"dev": true,
+			"bin": {
+				"playwright-core": "cli.js"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/playwright/node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
 		"node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,8 @@
 		"lint": "eslint .",
 		"test": "vitest run",
 		"test:watch": "vitest",
+		"test:e2e": "playwright test",
+		"test:e2e:approve": "playwright test --update-snapshots",
 		"preview": "vite preview"
 	},
 	"dependencies": {
@@ -21,6 +23,7 @@
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.39.1",
+		"@playwright/test": "^1.62.1",
 		"@tailwindcss/postcss": "^4.1.17",
 		"@types/react": "^19.2.5",
 		"@types/react-dom": "^19.2.3",

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -1,0 +1,58 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright — the pixel half of the test suite (issue #7).
+ *
+ * `npm test` (vitest) covers every non-React seam and deliberately mounts
+ * nothing; its `include` is `src/**\/*.test.js`, so it cannot see this folder.
+ * That separation is the point: these two suites never run in the same process
+ * and never import each other.
+ */
+export default defineConfig({
+	testDir: './e2e',
+
+	// A screenshot of a WebGL canvas is only comparable against another taken at
+	// the same size, so the viewport is fixed here rather than per test.
+	use: {
+		...devices['Desktop Chrome'],
+		viewport: { width: 1280, height: 800 },
+		baseURL: 'http://localhost:5173',
+	},
+
+	// Fail loudly on a regression rather than quietly re-baselining.
+	updateSnapshots: 'missing',
+
+	// One tidy folder, because it is gitignored. The baselines are frozen
+	// renders rather than source, so they are made on the machine that runs
+	// the suite and never committed.
+	snapshotPathTemplate: '{testDir}/__screenshots__/{arg}{ext}',
+
+	expect: {
+		toHaveScreenshot: {
+			// **Not one pixel may differ.** The issue asked for a tolerance that
+			// survives driver-level antialiasing, which is the right ask when
+			// baselines are shared between machines. These are not: they are
+			// generated where they are checked, so there is one driver, and the
+			// render is bit-exact across repeated runs — five in a row, fresh
+			// browser each time, zero differing pixels.
+			//
+			// A tolerance costs sensitivity and buys nothing here. Measured
+			// against the frozen renders, widening trim stock by 2 in moves 756
+			// px of the barn and 1513 of the gable; a `maxDiffPixelRatio` of
+			// 0.002 allows 961, so it passed a two-inch change on the barn. At
+			// zero, a fifth of an inch (4 px) fails.
+			//
+			// `threshold` is left at its 0.2 default, so a pixel has to differ
+			// in colour by a visible amount to count at all. That is the part
+			// that absorbs noise; the pixel count is what stays strict.
+			maxDiffPixels: 0,
+		},
+	},
+
+	webServer: {
+		command: 'npm run dev',
+		url: 'http://localhost:5173',
+		reuseExistingServer: !process.env.CI,
+		timeout: 60_000,
+	},
+});

--- a/frontend/src/utils/modelSpec.js
+++ b/frontend/src/utils/modelSpec.js
@@ -69,7 +69,7 @@ export function wallHeightFt(model) {
  * How far the ridge stands above the eave, in feet.
  *
  * The rafters are cut to a fixed pitch, so this follows the span: a 6:12 Gable,
- * or a 12:12 / 4:12 gambrel whose Knuckle splits the rise evenly.
+ * or a 20:12 / 4:12 gambrel whose Knuckle splits the rise evenly.
  *
  * @param {'Barn'|'Gable'} model
  * @param {number} width - span in feet

--- a/frontend/src/utils/roofGeometry.js
+++ b/frontend/src/utils/roofGeometry.js
@@ -302,9 +302,12 @@ export const GAMBREL_UPPER_PITCH = 4;
  * read as a gambrel instead of a kinked gable. Solving
  * `r·U = (1 - r)·L` gives `r = L / (L + U)`.
  *
- * For the 12:12 / 4:12 spec that is 0.75, and the roof then rises a quarter of
- * its span — the same "25%" the Gable's 6:12 is quoted as, so the two Models
- * carry the same overall proportion.
+ * For the 20:12 / 4:12 spec that is 5/6, and the roof then rises 5/18 of its
+ * span at every catalog width — a little more than the quarter the Gable's
+ * 6:12 is quoted as. The two Models did carry the same overall proportion back
+ * when the sides were quoted as a 12 pitch, which is where the retired "0.75,
+ * and the same 25% as the Gable" came from; steepening them to the 20 the
+ * photographs measure took the Barn above it.
  *
  * The hand-set 0.82 it replaces has no recorded source. It happens to be close
  * to what this rule gives for the old 24:12 / 6:12 pair (0.8), which suggests


### PR DESCRIPTION
Closes #7.

The 3D canvas is the whole output of the product and no vitest seam touches it — every seam under test is non-React by design, so tests and a clean build can both pass while the app is broken on screen. This closes that gap for the two approved reference Designs.

`frontend/e2e/reference-match.spec.js` drives the Reference Match page through the browser — nav, then the target button — and freezes the canvas of each target. It **imports no component and no geometry function**: the seam is the `<canvas>` and only the `<canvas>` (ADR-0012). The Reference Photo beside it is out of frame, because `reference/` is gitignored and a baseline holding the "no reference photo" placeholder would fail on every machine but the one that made it.

```bash
cd frontend && npm run test:e2e
```

## No behaviour changes

vitest is unchanged at **185 passed | 1 expected fail | 1 todo**, `go test ./...` is green, and `npm run lint` is back to the **7 pre-existing errors** — the eslint change is a node-globals block so the runner's `Buffer` and `process` do not read as undefined.

The screenshot commit touches nothing under `frontend/src` at all. The follow-up docstring commit edits two comments there and no code; both frozen renders still match to the pixel, which is the suite's first real job.

## Three things the red-green loop caught

**A green test that could not fail.** The first "canvas is not blank" check passed on its first run. Denying the page WebGL to prove it *could* go red showed it could not: the page paints a badge over the top left of its own canvas, so the two regions being compared differed for a DOM reason whether or not anything had been drawn. Both squares now come off the right edge.

**The baseline would have been a grey box.** Waiting on `width * height > 0` returns too early. The `<Canvas>` is keyed by target id so R3F picks up each target's camera, so switching target remounts it, and a fresh canvas spends a moment at the HTML default 300 × 150 — which is what `gable-front` measured while `barn-barndoors` measured 639 × 752. The wait is now for the canvas to reach its pane.

**The tolerance was hiding regressions.** Set to the `maxDiffPixelRatio: 0.002` the issue asks for, then measured against the frozen renders:

| `TRIM_WIDTH` vs 4in | barn px | gable px |
|---|---|---|
| +0.2in | 0 | 4 |
| +0.32in | 4 | 12 |
| +0.8in | 157 | 457 |
| +2in | 756 | 1513 |

0.002 of 639 × 752 permits 961 differing pixels, so a **two-inch** trim change passed on the barn.

## One deliberate deviation from the issue

The issue asks for "a tolerance that survives driver-level AA differences". That is right when baselines are shared between machines. **These are not** — they are generated where they are checked, and the render is bit-exact across five consecutive runs with a fresh browser each time. So `maxDiffPixels: 0`, and a fifth of an inch now fails. `threshold` stays at its 0.2 default, so a pixel still has to differ visibly in colour to count at all — that is the part that absorbs noise; the pixel count is what stays strict.

The honest limit: the floor is the render's own resolution, not the tolerance. The barn is a 53 ft three-quarter view and does not move at all until about a third of an inch.

## Baselines are not committed

Agreed with @hunterMotko before writing anything: they are frozen renders rather than source, so each machine makes its own under `e2e/__screenshots__/` (gitignored). **A clone's first run writes them and fails**, and the second run is the first that means anything — loud rather than a silent pass, verified by deleting them and re-running. `npm run test:e2e:approve` re-freezes them and is a sign-off, not a way past a red test.

The trade this accepts: with no committed baseline there is nothing for CI or a fresh clone to compare against, so this catches regressions on the machine that runs it rather than in CI. There is no `.github/` workflow in the repo today either way.

## The SwiftShader flags were not needed

Issue #7 warns that headless WebGL needs `--use-gl=angle --use-angle=swiftshader --enable-unsafe-swiftshader`. It did not here — Playwright's bundled Chromium Headless Shell 151 gives a `webgl2` context unaided, and forcing SwiftShader would only change the pixels the baselines are made of. Documented in CLAUDE.md for whoever hits a null context on another machine.

## Second commit: two stale docstrings (`7263782`)

Reported separately and confirmed against the shipping code. Both still describe the **retired 12:12 / 4:12** gambrel; the constants, CONTEXT.md and CLAUDE.md all agree on 20:12 lower and 4:12 upper.

`gambrelKnuckleRatio` was wrong twice over. Its quoted 0.75 is what `L / (L + U)` gives for 12 and 4 — the shipping pitches give **5/6**. And the sentence built on it, that the roof "rises a quarter of its span … the same 25% the Gable's 6:12 is quoted as, so the two Models carry the same overall proportion", was a real claim the steeper sides falsified:

| | shipping (20:12/4:12) | docstring said |
|---|---|---|
| knuckle ratio | 0.8333 (5/6) | 0.75 |
| barn rise ÷ span | 0.27778 (5/18), every catalog width | "a quarter of its span" |
| gable rise ÷ span | 0.25 exactly | — |

The two Models *did* match at 12:12 / 4:12, which is where the retired numbers came from, so the correction records that rather than deleting it. `roofRiseFt` names the same stale pair in one clause; the rest of that sentence stands, since the Knuckle does still split the rise evenly at any pitch pair by construction.

A third report — that `@dimforge/rapier3d-compat` is missing from `package.json` — is accurate but is not a bug: it arrives transitively via `drei → maath → @types/three`, has zero source references, and there is no physics dependency here to declare or remove.

## Worth knowing before merging

The baselines bake in today's render, including the two fidelity questions flagged when the fixtures were measured: the photographed gable reads **5.2:12** against the 6:12 spec, and the photographed barn side wall reads **28 ft** against the fixture's 20. The suite will now defend those numbers as correct until someone changes `referenceTargets.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpBS1UKbHqnu3ox13Rohte
